### PR TITLE
Migrate all accounts to central sources

### DIFF
--- a/ansible/group_vars/netlogon.yml
+++ b/ansible/group_vars/netlogon.yml
@@ -1,0 +1,8 @@
+sshd_AuthorizedKeysCommand: /usr/bin/netkeys --ID %u
+sshd_AllowGroupsAlways:
+  - wheel
+  - dante
+
+netlogon_maintenance_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC9KC4FQ9SR0LOiZPAeNbiW2bpWHUdACkfMkmZoyuSGRdNazMwOFu3X5UR08if7uVIwbQItMDauxEP8H2zq/ChcOl5ZDbPO9EhIFZmnRCGHB2YtaMeT+w43zbLrnA9FC3Z3wNsNvqzerwaF2nmb1RNaJzLdzEj6dx+rqnPfk2FZj3v0Lgl+A2UAqK0W+uK+l/sS0vMTlWVdTKZuOgmu1nLt3ljeFVYOqWcaeqN+oIOargVA+4yas+N1YTAtNp6ShLqhIaNQS03kXSqHROFT6u5U4Aub7ryQPVyYasriW8dvxWQ41FZ26GcBPL1isMq348Ljgk7W5enGaDc7Xpmy8OMR maldridge@theGibson
+  - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGOy95ArbSNI2QXSIKfr2qyyrb2mNL2ER1sUkVBhtufh maldridge@deepblue

--- a/ansible/host_vars/vm2.a-lej-de.m.voidlinux.org.yml
+++ b/ansible/host_vars/vm2.a-lej-de.m.voidlinux.org.yml
@@ -1,6 +1,6 @@
 ---
 network_input_policy: DROP
-network_output_policy: DROP
+network_output_policy: ACCEPT
 
 network_interfaces:
   - name: eth0

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -29,6 +29,9 @@ vm1.a-lej-de.m.voidlinux.org
 [netauth]
 vm2.a-lej-de.m.voidlinux.org
 
+[netlogon]
+vm2.a-lej-de.m.voidlinux.org
+
 [unmanaged]
 a-mci-us.m.voidlinux.org
 a-lej-de.m.voidlinux.org

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -26,6 +26,9 @@ vm1.a-mci-us.m.voidlinux.org
 [mirrormanager]
 vm1.a-lej-de.m.voidlinux.org
 
+[netauth]
+vm2.a-lej-de.m.voidlinux.org
+
 [unmanaged]
 a-mci-us.m.voidlinux.org
 a-lej-de.m.voidlinux.org

--- a/ansible/netauth.yml
+++ b/ansible/netauth.yml
@@ -5,3 +5,4 @@
   become_user: root
   roles:
     - netauthd
+    - netlogon

--- a/ansible/netauth.yml
+++ b/ansible/netauth.yml
@@ -1,0 +1,7 @@
+---
+- hosts: netauth
+  become: yes
+  become_method: sudo
+  become_user: root
+  roles:
+    - netauthd

--- a/ansible/roles/netauth-config/files/netauth.rules
+++ b/ansible/roles/netauth-config/files/netauth.rules
@@ -1,0 +1,3 @@
+*filter
+-A OUTPUT -p tcp -d netauth.voidlinux.org --dport 8443 -j ACCEPT
+COMMIT

--- a/ansible/roles/netauth-config/files/netauth.toml
+++ b/ansible/roles/netauth-config/files/netauth.toml
@@ -1,0 +1,3 @@
+Server="netauth.voidlinux.org"
+Port=8443
+ServerCert="/usr/share/netauth/netauth.pem"

--- a/ansible/roles/netauth-config/tasks/main.yml
+++ b/ansible/roles/netauth-config/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+- name: Configure NetAuth library
+  copy:
+    src: netauth.toml
+    dest: /etc/netauth.toml
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Ensure data directory
+  file:
+    path: /usr/share/netauth/
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Install NetAuth Certificate
+  copy:
+    src: secret/netauth_tls_certificate.pem
+    dest: /usr/share/netauth/netauth.pem
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Install Token Verification Key
+  copy:
+    src: secret/netauth_token.pem
+    dest: /usr/share/netauth/token.pem
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Install Firewall Rules
+  copy:
+    src: netauth.rules
+    dest: /etc/iptables.d/
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - iptables

--- a/ansible/roles/netauthd/files/netauthd.rules
+++ b/ansible/roles/netauthd/files/netauthd.rules
@@ -1,0 +1,3 @@
+*filter
+-A INPUT -p tcp --dport 8443 -j ACCEPT
+COMMIT

--- a/ansible/roles/netauthd/handlers/main.yml
+++ b/ansible/roles/netauthd/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: netauthd
+  debug:
+    msg: netauthd should be restarted!

--- a/ansible/roles/netauthd/meta/main.yml
+++ b/ansible/roles/netauthd/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: network }

--- a/ansible/roles/netauthd/tasks/main.yml
+++ b/ansible/roles/netauthd/tasks/main.yml
@@ -1,0 +1,97 @@
+---
+- name: Install NetAuth Server
+  xbps:
+    pkg:
+      - NetAuth-server
+      - sv-helper
+    state: present
+
+- name: Create group
+  group:
+    name: _netauthd
+    state: present
+
+- name: Create unprivileged user
+  user:
+    name: _netauthd
+    group: _netauthd
+    create_home: yes
+    home: /var/lib/netauthd
+    system: yes
+    state: present
+
+- name: Create data directories
+  file:
+    path: "/var/lib/netauthd/{{ item }}"
+    state: directory
+    owner: _netauthd
+    group: _netauthd
+    mode: 0750
+  with_items:
+    - data
+    - security
+
+- name: Install TLS Certificate
+  copy:
+    src: "{{ item }}"
+    dest: /var/lib/netauthd/security/
+    owner: root
+    group: _netauthd
+    mode: 0640
+  no_log: true
+  with_items:
+    - secret/netauth_tls_certificate.pem
+    - secret/netauth_tls_certificate.key
+  notify:
+    - netauthd
+
+- name: Install Token Keys
+  copy:
+    src: "{{ item }}"
+    dest: /var/lib/netauthd/security
+    owner: root
+    group: _netauthd
+    mode: 0640
+  no_log: true
+  with_items:
+    - secret/netauth_token.key
+    - secret/netauth_token.pem
+  notify:
+    - netauthd
+
+- name: Install Firewall Rules
+  copy:
+    src: netauthd.rules
+    dest: /etc/iptables.d/
+    owner: root
+    group: root
+    mode: 0640
+  notify:
+    - iptables
+
+- name: Install Service (1/3)
+  file:
+    path: /etc/sv/{{ item }}
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  with_items:
+    - netauthd
+    - netauthd/log
+
+- name: Install Service (2/3)
+  template:
+    src: run.j2
+    dest: /etc/sv/netauthd/run
+    owner: root
+    group: root
+    mode: 0755
+  notify:
+    - netauthd
+
+- name: Install Service (3/3)
+  file:
+    src: /usr/bin/rsvlog
+    dest: /etc/sv/netauthd/log/run
+    state: link

--- a/ansible/roles/netauthd/templates/run.j2
+++ b/ansible/roles/netauthd/templates/run.j2
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+cd /var/lib/netauthd || exit 1
+
+exec chpst -u _netauthd:_netauthd netauthd \
+     --bind "" \
+     --port 8443 \
+     --key_file security/netauth_tls_certificate.key \
+     --cert_file security/netauth_tls_certificate.pem \
+     --db ProtoDB \
+     --protodb_root ./data \
+     --crypto bcrypt \
+     --bcrypt_cost 10 \
+     --token_lifetime 20m \
+     --token_renewals 0 \
+     --token_impl jwt-rsa \
+     --jwt_rsa_privatekey security/netauth_token.key \
+     --jwt_rsa_publickey security/netauth_token.pem \
+     2>&1

--- a/ansible/roles/netlogon/defaults/main.yml
+++ b/ansible/roles/netlogon/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+netlogon_maintenance_user: maintenance

--- a/ansible/roles/netlogon/files/base.policy
+++ b/ansible/roles/netlogon/files/base.policy
@@ -1,0 +1,3 @@
+[group:netusers]
+renew=1w
+expire=3w

--- a/ansible/roles/netlogon/files/dante.sudoers
+++ b/ansible/roles/netlogon/files/dante.sudoers
@@ -1,0 +1,1 @@
+%dante ALL=(ALL) ALL

--- a/ansible/roles/netlogon/files/nsscache.run
+++ b/ansible/roles/netlogon/files/nsscache.run
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+nsscache
+
+exec sleep $(( 30 * 60 ))

--- a/ansible/roles/netlogon/files/nsswitch.conf
+++ b/ansible/roles/netlogon/files/nsswitch.conf
@@ -1,0 +1,11 @@
+passwd:         files cache
+group:          files cache
+shadow:         files cache
+
+hosts:          files myhostname dns
+networks:       files
+
+protocols:      files
+services:       files
+ethers:         files
+rpc:            files

--- a/ansible/roles/netlogon/files/sudoers
+++ b/ansible/roles/netlogon/files/sudoers
@@ -1,0 +1,8 @@
+# root bypass
+root ALL=(ALL) ALL
+
+# Local wheel group
+%wheel ALL=(ALL) ALL
+
+# Drop-in config
+#includedir /etc/sudoers.d

--- a/ansible/roles/netlogon/files/system-auth
+++ b/ansible/roles/netlogon/files/system-auth
@@ -1,0 +1,22 @@
+#%PAM-1.0
+
+auth    [success=4 default=ignore] pam_unix.so try_first_pass nullok
+auth    [success=3 default=ignore] pam_policycache.so action=check
+auth    [success=ok default=die] pam_netauth.so try_first_pass
+auth    [success=1 default=ignore] pam_policycache.so action=update
+auth    required  pam_deny.so
+auth    required  pam_env.so
+auth    required  pam_permit.so
+
+account   required  pam_unix.so
+account   optional  pam_permit.so
+account   required  pam_time.so
+
+password  required  pam_unix.so     try_first_pass nullok sha512 shadow
+password  optional  pam_permit.so
+
+session   required  pam_mkhomedir.so
+session   optional  pam_umask.so    usergroups
+session   required  pam_limits.so
+session   required  pam_unix.so
+session   optional  pam_permit.so

--- a/ansible/roles/netlogon/meta/main.yml
+++ b/ansible/roles/netlogon/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: netauth-config }

--- a/ansible/roles/netlogon/tasks/main.yml
+++ b/ansible/roles/netlogon/tasks/main.yml
@@ -1,0 +1,98 @@
+---
+- name: Create local management group
+  group:
+    name: "{{ netlogon_maintenance_user }}"
+    state: present
+
+- name: Create local management user
+  user:
+    name: "{{ netlogon_maintenance_user }}"
+    group: "{{ netlogon_maintenance_user }}"
+    state: present
+    createhome: yes
+
+- name: Install management keys (1/2)
+  file:
+    path: /home/{{ netlogon_maintenance_user }}/.ssh
+    state: directory
+    owner: "{{ netlogon_maintenance_user }}"
+    group: "{{ netlogon_maintenance_user }}"
+    mode: 0700
+
+- name: Install management keys (2/2)
+  template:
+    src: authorized_keys.j2
+    dest: /home/{{ netlogon_maintenance_user }}/.ssh/authorized_keys
+    owner: "{{ netlogon_maintenance_user }}"
+    group: "{{ netlogon_maintenance_user }}"
+    mode: 0600
+
+- name: Install Packages
+  xbps:
+    pkg:
+      - NetAuth-nsscache
+      - NetKeys
+      - libnss-cache
+      - pam_netauth
+    state: present
+
+- name: Install nsscache Service (1/2)
+  file:
+    path: /etc/sv/nsscache
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Install nsscache Service (2/2)
+  copy:
+    src: nsscache.run
+    dest: /etc/sv/nsscache/run
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Enable nsscache Service
+  runit:
+    name: nsscache
+    enabled: true
+
+- name: Configure NSS
+  copy:
+    src: nsswitch.conf
+    dest: /etc/nsswitch.conf
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Install PAM Cache Policy
+  copy:
+    src: base.policy
+    dest: /etc/libpam-policycache.d/
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Configure PAM
+  copy:
+    src: system-auth
+    dest: /etc/pam.d/system-auth
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Configure sudo
+  copy:
+    src: sudoers
+    dest: /etc/sudoers
+    owner: root
+    group: root
+    mode: 0640
+
+- name: Install sudo policy
+  copy:
+    src: dante.sudoers
+    dest: /etc/sudoers.d/dante
+    owner: root
+    group: root
+    mode: 0640

--- a/ansible/roles/netlogon/templates/authorized_keys.j2
+++ b/ansible/roles/netlogon/templates/authorized_keys.j2
@@ -1,0 +1,3 @@
+{% for key in netlogon_maintenance_keys %}
+{{ key }}
+{% endfor %}


### PR DESCRIPTION
This PR adds the infrastructure to migrate all system accounts for Void infrastructure to a central system.  It also provides a convenient way to provide information about migrating existing users.

Why
---
Currently there's a mish-mash of local users across various boxes provisioned by hand, this is sub-optimal.  These accounts are not managed in any way and changes to anything requires changes to be propagated to other hosts by hand.  This also means that we don't have a good way to grant temporary access to machines nor do we have a good way to apply login policy across the fleet.

How
---
Shameless plug, I built tooling that does this.  Without getting into a huge discussion of why I went the long way round, the primary reason was it needed to be easy to run and easy to maintain.  It also needed to be safe to run over the internet at large, since setting up a ton of VPNs wasn't an option.  The long term plan is that the build machines are minimally trusted anyway, so VPNs and WAN Mesh networking isn't a good idea anyway.

The software is called NetAuth, and it stores general authentication and authorization information.  There is no central filesystem, home directories remain local to each machine but now live on the tmpfs.  They're created on login and go away whenever the tmpfs gets cleared, likely on reboot.

Some FAQs:

Q: What happens if the NetAuth server crashes?
A: The NSS maps are all cached locally, they'll be fine indefinitely but will become stale.  Authentication information is cached locally as well (passwords not keys) so if you're already on a machine your session won't die.  Key caching may become a feature if people ask for it, but not in the initial launch.

Q: How is the NetAuth server secured?
A: The server is on a dedicated VM which has extremely tight ACLs.  The server itself uses bcrypt to secure secrets, is only available over TLS, and uses other cryptographic mechanisms to ensure responses cannot be forged.

Q: What happens if things are totally fubar'd?
A: Well hopefully we have plenty of warning before that happens, but if it does, there's a standby account that's fully local and has a few dedicated keys that can log in as that user.

Migration
---------
To migrate existing accounts we need to kill off the old accounts since they would cause a uid collision (note uid, not uidNumber).

Here's your chance to change your username!

Right now these are the accounts that will be migrated over:
  * duncaen (@Duncaen) 
  * leah2 (@chneukirchen)
  * tox (@Gottox)
  * vaelatern (@Vaelatern)

Unless the users above contact me here in this thread, those are the names I'll move over.  Double check this is what you want, since some people in the above list have multiple names on multiple servers.

I'll migrate at least one key or if specific keys are requested I can provide those instead.  Your passwords will be reset during this move, contact will be made out of band to provide the temporary password for you to reset.

Feel free to bikeshed below.