### PR TITLE
Add DNS for repos on voidlinux.org

### DIFF
--- a/terraform/google-dns.tf
+++ b/terraform/google-dns.tf
@@ -227,3 +227,71 @@ resource "google_dns_record_set" "service-sources" {
   rrdatas = ["vm1.a-lej-de.m.voidlinux.org."]
 }
 
+#######################################################################
+# Mirror Records                                                      #
+#                                                                     #
+# These records are largely for failover when the more intelligent    #
+# mirror router is unavailable.  This section should be hierarchical. #
+#######################################################################
+
+resource "google_dns_record_set" "mirror-root" {
+  name = "repo.${google_dns_managed_zone.voidlinux-org.dns_name}"
+  managed_zone = "${google_dns_managed_zone.voidlinux-org.name}"
+
+  type    = "CNAME"
+  ttl     = 300
+  rrdatas = [
+    "de.repo.${google_dns_managed_zone.voidlinux-org.dns_name}",
+    "us.repo.${google_dns_managed_zone.voidlinux-org.dns_name}"
+  ]
+}
+
+resource "google_dns_record_set" "mirror-de-root" {
+  name = "de.repo.${google_dns_managed_zone.voidlinux-org.dns_name}"
+  managed_zone = "${google_dns_managed_zone.voidlinux-org.name}"
+
+  type    = "CNAME"
+  ttl     = 300
+  rrdatas = [
+    "alpha.de.repo.${google_dns_managed_zone.voidlinux-org.dns_name}",
+    "beta.de.repo.${google_dns_managed_zone.voidlinux-org.dns_name}"
+  ]
+}
+
+resource "google_dns_record_set" "mirror-de-1" {
+  name = "alpha.de.repo.${google_dns_managed_zone.voidlinux-org.dns_name}"
+  managed_zone = "${google_dns_managed_zone.voidlinux-org.name}"
+
+  type    = "CNAME"
+  ttl     = 300
+  rrdatas = ["vm1.a-lej-de.m.voidlinux.org."]
+}
+
+resource "google_dns_record_set" "mirror-de-2" {
+  name = "beta.de.repo.${google_dns_managed_zone.voidlinux-org.dns_name}"
+  managed_zone = "${google_dns_managed_zone.voidlinux-org.name}"
+
+  type    = "CNAME"
+  ttl     = 300
+  rrdatas = ["repo2.voidlinux.eu."]
+}
+
+resource "google_dns_record_set" "mirror-us-root" {
+  name = "us.repo.${google_dns_managed_zone.voidlinux-org.dns_name}"
+  managed_zone = "${google_dns_managed_zone.voidlinux-org.name}"
+
+  type    = "CNAME"
+  ttl     = 300
+  rrdatas = [
+    "alpha.us.repo.${google_dns_managed_zone.voidlinux-org.dns_name}"
+  ]
+}
+
+resource "google_dns_record_set" "mirror-us-1" {
+  name = "alpha.us.repo.${google_dns_managed_zone.voidlinux-org.dns_name}"
+  managed_zone = "${google_dns_managed_zone.voidlinux-org.name}"
+
+  type    = "CNAME"
+  ttl     = 300
+  rrdatas = ["vm1.a-mci-us.m.${google_dns_managed_zone.voidlinux-org.dns_name}"]
+}


### PR DESCRIPTION
Today all services were migrated so that the .org name is the primary and the legacy .eu name is a secondary name.  As part of this move it came up that we should have something for the repos.  Ultimately I'd like repo.voidlinux.org to map to auto.voidlinux.org, but until some host shuffling happens this isn't going to be terribly reliable anyway.

This commit adds some DNS names for the repos that we currently have so that people can use them in the meantime.  Here's the state delta:

```
Terraform will perform the following actions:

  + google_dns_record_set.mirror-de-1
      id:           <computed>
      managed_zone: "voidlinux-org"
      name:         "alpha.de.repo.voidlinux.org."
      project:      <computed>
      rrdatas.#:    "1"
      rrdatas.0:    "vm1.a-lej-de.m.voidlinux.org."
      ttl:          "300"
      type:         "CNAME"

  + google_dns_record_set.mirror-de-2
      id:           <computed>
      managed_zone: "voidlinux-org"
      name:         "beta.de.repo.voidlinux.org."
      project:      <computed>
      rrdatas.#:    "1"
      rrdatas.0:    "repo2.voidlinux.eu."
      ttl:          "300"
      type:         "CNAME"

  + google_dns_record_set.mirror-de-root
      id:           <computed>
      managed_zone: "voidlinux-org"
      name:         "de.repo.voidlinux.org."
      project:      <computed>
      rrdatas.#:    "2"
      rrdatas.0:    "alpha.de.repo.voidlinux.org."
      rrdatas.1:    "beta.de.repo.voidlinux.org."
      ttl:          "300"
      type:         "CNAME"

  + google_dns_record_set.mirror-root
      id:           <computed>
      managed_zone: "voidlinux-org"
      name:         "repo.voidlinux.org."
      project:      <computed>
      rrdatas.#:    "2"
      rrdatas.0:    "de.repo.voidlinux.org."
      rrdatas.1:    "us.repo.voidlinux.org."
      ttl:          "300"
      type:         "CNAME"

  + google_dns_record_set.mirror-us-1
      id:           <computed>
      managed_zone: "voidlinux-org"
      name:         "alpha.us.repo.voidlinux.org."
      project:      <computed>
      rrdatas.#:    "1"
      rrdatas.0:    "vm1.a-mci-us.m.voidlinux.org."
      ttl:          "300"
      type:         "CNAME"

  + google_dns_record_set.mirror-us-root
      id:           <computed>
      managed_zone: "voidlinux-org"
      name:         "us.repo.voidlinux.org."
      project:      <computed>
      rrdatas.#:    "1"
      rrdatas.0:    "alpha.us.repo.voidlinux.org."
      ttl:          "300"
      type:         "CNAME"


Plan: 6 to add, 0 to change, 0 to destroy.
```