### PR TITLE
Add xq-api infrastructure

### DIFF
--- a/ansible/build.yml
+++ b/ansible/build.yml
@@ -10,6 +10,7 @@
     - void-updates
     - live-mirror
     - sources_site
+    - xq-api
 
 - hosts: buildslave
   become: yes

--- a/ansible/host_vars/a-hel-fi.m.voidlinux.org.yml
+++ b/ansible/host_vars/a-hel-fi.m.voidlinux.org.yml
@@ -36,6 +36,9 @@ buildmaster_ssl_certkey_path: /var/lib/acme/live/build.voidlinux.org/privkey
 sources_site_cert_path: /var/lib/acme/live/sources.voidlinux.org/fullchain
 sources_site_key_path: /var/lib/acme/live/sources.voidlinux.org/privkey
 
+xqapi_site_cert_path: /var/lib/acme/live/xq-api.voidlinux.org/fullchain
+xqapi_site_key_path: /var/lib/acme/live/xq-api.voidlinux.org/privkey
+
 buildslave_zone: DE-1
 buildslave_master: localhost
 buildslave_isremote: false
@@ -67,6 +70,9 @@ acmetool:
     - site: sources.voidlinux.org
       names:
         - sources.voidlinux.org
+    - site: xq-api.voidlinux.org
+      names:
+        - xq-api.voidlinux.org
     - site: a-hel-fi.m.voidlinux.org
       names:
         - a-hel-fi.m.voidlinux.org

--- a/ansible/roles/xq-api/defaults/main.yml
+++ b/ansible/roles/xq-api/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+xqapi:
+xqapi_hup:

--- a/ansible/roles/xq-api/files/root.conf
+++ b/ansible/roles/xq-api/files/root.conf
@@ -1,0 +1,3 @@
+location / {
+    proxy_pass http://localhost:8197;
+}

--- a/ansible/roles/xq-api/handlers/main.yml
+++ b/ansible/roles/xq-api/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: xq-api
+  runit:
+    name: xq-api
+    state: restarted
+
+- name: xq-api-hup
+  runit:
+    name: xq-api-hup
+    state: restarted

--- a/ansible/roles/xq-api/meta/main.yml
+++ b/ansible/roles/xq-api/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: nginx }

--- a/ansible/roles/xq-api/tasks/main.yml
+++ b/ansible/roles/xq-api/tasks/main.yml
@@ -1,0 +1,76 @@
+---
+- name: Install packages
+  xbps:
+    pkg:
+      - xq-api
+      - snooze
+    state: present
+
+- name: Configure xq-api
+  template:
+    src: xq-api.conf.j2
+    dest: /etc/sv/xq-api/conf
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - xq-api
+
+- name: Install xq-api HUP service (1/2)
+  file:
+    path: /etc/sv/xq-api-hup
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Install xq-api HUP service (2/2)
+  template:
+    src: xq-api-hup.sh.j2
+    dest: /etc/sv/xq-api-hup/run
+    owner: root
+    group: root
+    mode: 0755
+  notify:
+    - xq-api-hup
+
+- name: Create xq-api log directory
+  file:
+    path: /var/log/xq-api
+    state: directory
+    owner: _xqapi
+    group: _xqapi
+    mode: 0755
+
+- name: Enable services
+  runit:
+    name: "{{ item }}"
+    enabled: yes
+  loop:
+    - xq-api
+    - xq-api-hup
+
+- name: Configure nginx base-site
+  include_role:
+    name: nginx
+    tasks_from: base-site
+  vars:
+    - site:
+        name: xq-api
+        urls:
+          - xq-api.voidlinux.org
+        use_ssl: "{{ void_aquire_certs }}"
+        ssl_certificate_path: "{{ xqapi_site_cert_path | default('/dev/null') }}"
+        ssl_key_path: "{{ xqapi_site_key_path | default('/dev/null') }}"
+        ssl_stapling: yes
+        static_root: no
+
+- name: Install location file
+  copy:
+    src: root.conf
+    dest: /etc/nginx/locations.d/xq-api.voidlinux.org/
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - nginx

--- a/ansible/roles/xq-api/templates/xq-api-hup.sh.j2
+++ b/ansible/roles/xq-api/templates/xq-api-hup.sh.j2
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec snooze -H {{ xqapi_hup.hour | default('*') | quote }} -M {{ xqapi_hup.minute | default('/5') | quote }} /usr/bin/sv hup xq-api

--- a/ansible/roles/xq-api/templates/xq-api.conf.j2
+++ b/ansible/roles/xq-api/templates/xq-api.conf.j2
@@ -1,0 +1,8 @@
+NET={{ xqapi.listen_net | default('tcp') }}
+ADDR={{ xqapi.listen_addr | default('127.0.0.1:8197') }}
+MAX_QUERIES={{ xqapi.max_queries | default(16) }}
+LOG_V={{ xqapi.log_v | default(None) }}
+LOG_ACCESS={{ 't' if (xqapi.log_access | default(False)) else 'f' }}
+LOG_TO_STDERR={{ 't' if (xqapi.log_to_stderr | default(False)) else 'f' }}
+LOG_DIR={{ xqapi.log_dir | default(None) }}
+REPODATA={{ xqapi.repodata | default('/var/db/xbps') }}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -20,6 +20,7 @@
   - [rsyncd](./services/rsyncd.md)
   - [void-updates](./services/void-updates.md)
   - [xlocate](./services/xlocate.md)
+  - [xq-api](./services/xq-api.md)
 - [Organization](./org/index.md)
   - [Onboarding](./org/onboarding.md)
   - [Offboarding](./org/offboarding.md)

--- a/docs/src/services/xq-api.md
+++ b/docs/src/services/xq-api.md
@@ -1,0 +1,8 @@
+# xq-api
+
+xq-api is a server that reads local repodata and serves it over HTTP. It is used
+to provide package search and package information to users.
+
+Information about xq-api, such as paths served by xq-api and the data it
+returns, can be read in its man page, xq-api(8), and at its [GitHub
+repository](https://github.com/nilium/xq-api).

--- a/terraform/google-dns.tf
+++ b/terraform/google-dns.tf
@@ -284,6 +284,16 @@ resource "google_dns_record_set" "service-terraform" {
   rrdatas = ["vm2.a-lej-de.m.voidlinux.org."]
 }
 
+resource "google_dns_record_set" "service-xqapi" {
+  # XBPS repodata API (xq-api)
+  name = "xq-api.${google_dns_managed_zone.voidlinux-org.dns_name}"
+  managed_zone = "${google_dns_managed_zone.voidlinux-org.name}"
+
+  type    = "CNAME"
+  ttl     = 300
+  rrdatas = ["a-hel-fi.m.voidlinux.org."]
+}
+
 #######################################################################
 # Mirror Records                                                      #
 #                                                                     #


### PR DESCRIPTION
- Adds an Ansible role for xq-api. Currently added under the buildmaster in the build playbook. The role defines an xq-api.voidlinux.org site.
- Adds a DNS record under Terraform for xq-api.voidlinux.org.
- Adds a short description of the service to docs.