### PR TITLE
terraform: Create document writers team

### DIFF
--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -148,6 +148,12 @@ resource "github_team" "void-ops" {
   privacy = "closed"
 }
 
+resource "github_team" "doc-writers" {
+  name = "doc-writers"
+  description = "Document Writers"
+  pricacy = "closed"
+}
+
 ###############
 # Memberships #
 ###############
@@ -180,6 +186,14 @@ resource "github_team_repository" "void-mklive" {
 }
 
 resource "github_team_repository" "void-docs" {
+  team_id    = "${github_team.doc-writers.id}"
+  repository = "${github_repository.void-docs.name}"
+  permission = "push"
+}
+
+resource "github_team_repository" "void-docs" {
+  # Document writers are also allowed to merge to the void-docs
+  # repository.
   team_id    = "${github_team.pkg-committers.id}"
   repository = "${github_repository.void-docs.name}"
   permission = "push"

--- a/terraform/github_members.tf
+++ b/terraform/github_members.tf
@@ -67,6 +67,28 @@ resource "github_team_membership" "void-ops_the-maldridge" {
   username = "the-maldridge"
 }
 
+####################
+# Document Writers #
+####################
+
+resource "github_team_membership" "doc-writers_the-maldridge" {
+  team_id = "${github_team.doc-writers.id}"
+  role = "maintainer"
+  username = "the-maldridge"
+}
+
+resource "github_team_membership" "doc-writers_bobertlo" {
+  team_id = "${github_team.doc-writers.id}"
+  role = "member"
+  username = "bobertlo"
+}
+
+resource "github_team_membership" "doc-writers_nilium" {
+  team_id = "${github_team.doc-writers.id}"
+  role = "member"
+  username = "Nilium"
+}
+
 ######################
 # Package Committers #
 ######################


### PR DESCRIPTION
As discussed earlier, writing and reviewing docs have different permissions associated with them compared to pushing packages.