### PR TITLE
terraform: xbps repo gets its own permission group

### DIFF
--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -142,6 +142,12 @@ resource "github_team" "pkg-committers" {
   privacy = "closed"
 }
 
+resource "github_team" "xbps-developers" {
+  name = "xbps-developers"
+  description = "The people that build XBPS"
+  privacy = "closed"
+}
+
 resource "github_team" "void-ops" {
   name = "void-ops"
   description = "Infrastructure Operators"
@@ -236,7 +242,7 @@ resource "github_team_repository" "socklog-void" {
 }
 
 resource "github_team_repository" "xbps" {
-  team_id    = "${github_team.pkg-committers.id}"
+  team_id    = "${github_team.xbps-developers.id}"
   repository = "${github_repository.xbps.name}"
   permission = "push"
 }

--- a/terraform/github_members.tf
+++ b/terraform/github_members.tf
@@ -172,3 +172,19 @@ resource "github_team_membership" "pkg-committers_thypon" {
   role = "member"
   username = "thypon"
 }
+
+###################
+# XBPS Developers #
+###################
+
+# These memberships belong to groups defined in github.tf.  These are
+# sorted by lexical sort order keyed on the username.  This order is
+# manually preserved, please be careful when editing.
+
+# Maintainers
+
+resource "github_team_membership" "xbps-developers_duncaen" {
+  team_id = "${github_team.xbps-developers.id}"
+  role = "maintainer"
+  username = "Duncaen"
+}


### PR DESCRIPTION
The way that permissions work now has always been a bit of a hack.  We use one massive group to grant everything and that's not a sustainable solution.  Here's the first bit of breaking up things which logically splits people who update packages from people who handle the innards of XBPS.

In this PR I'm just moving things around, not adding new things.  @Duncaen anyone besides you that you think should have direct push access who previously had it via pkg-committers?

Here's the state delta so far.  I expect it to grow as more repos get split off from pkg-committers.

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
-/+ destroy and then create replacement

Terraform will perform the following actions:

  + github_team.xbps-developers
      id:          <computed>
      description: "The people that build XBPS"
      name:        "xbps-developers"
      privacy:     "closed"

  + github_team_membership.xbps-developers_duncaen
      id:          <computed>
      role:        "maintainer"
      team_id:     "${github_team.xbps-developers.id}"
      username:    "Duncaen"

-/+ github_team_repository.xbps (new resource required)
      id:          "2795568:xbps" => <computed> (forces new resource)
      permission:  "push" => "push"
      repository:  "xbps" => "xbps"
      team_id:     "2795568" => "${github_team.xbps-developers.id}" (forces new resource)


Plan: 3 to add, 0 to change, 1 to destroy.
```