### PR TITLE
terraform: web content is managed by webmasters

### DIFF
--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -160,6 +160,12 @@ resource "github_team" "doc-writers" {
   privacy = "closed"
 }
 
+resource "github_team" "webmasters" {
+  name = "webmasters"
+  description = "Reviewers for voidlinux.org"
+  privacy = "closed"
+}
+
 ###############
 # Memberships #
 ###############
@@ -230,7 +236,7 @@ resource "github_team_repository" "void-updates" {
 }
 
 resource "github_team_repository" "void-linux-website" {
-  team_id    = "${github_team.pkg-committers.id}"
+  team_id    = "${github_team.webmasters.id}"
   repository = "${github_repository.void-linux-website.name}"
   permission = "push"
 }

--- a/terraform/github_members.tf
+++ b/terraform/github_members.tf
@@ -67,6 +67,38 @@ resource "github_team_membership" "void-ops_the-maldridge" {
   username = "the-maldridge"
 }
 
+##############
+# Webmasters #
+##############
+
+# Maintainers
+
+resource "github_team_membership" "webmasters_duncaen" {
+  team_id = "${github_team.webmasters.id}"
+  role = "maintainer"
+  username = "Duncaen"
+}
+
+resource "github_team_membership" "webmasters_gottox" {
+  team_id = "${github_team.webmasters.id}"
+  role = "maintainer"
+  username = "Gottox"
+}
+
+resource "github_team_membership" "webmasters_the-maldridge" {
+  team_id = "${github_team.webmasters.id}"
+  role = "maintainer"
+  username = "the-maldridge"
+}
+
+# Members
+
+resource "github_team_membership" "webmasters_vaelatern" {
+  team_id = "${github_team.webmasters.id}"
+  role = "member"
+  username = "Vaelatern"
+}
+
 ####################
 # Document Writers #
 ####################


### PR DESCRIPTION
Part of #29 

This PR restricts down the ability to push to voidlinux.org from the entire pool of package maintainers to only those that regularly manage the website.