### PR TITLE
terraform: Remove automatic permissions to 'read-only' repositories

### DIFF
--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -211,86 +211,14 @@ resource "github_team_repository" "void-docs-dedicated" {
   permission = "push"
 }
 
-resource "github_team_repository" "void-wiki" {
-  team_id    = "${github_team.pkg-committers.id}"
-  repository = "${github_repository.void-wiki.name}"
-  permission = "push"
-}
-
-resource "github_team_repository" "void-texlive" {
-  team_id    = "${github_team.pkg-committers.id}"
-  repository = "${github_repository.void-texlive.name}"
-  permission = "push"
-}
-
-resource "github_team_repository" "void-runit" {
-  team_id    = "${github_team.pkg-committers.id}"
-  repository = "${github_repository.void-runit.name}"
-  permission = "push"
-}
-
-resource "github_team_repository" "void-updates" {
-  team_id    = "${github_team.pkg-committers.id}"
-  repository = "${github_repository.void-updates.name}"
-  permission = "push"
-}
-
 resource "github_team_repository" "void-linux-website" {
   team_id    = "${github_team.webmasters.id}"
   repository = "${github_repository.void-linux-website.name}"
   permission = "push"
 }
 
-resource "github_team_repository" "socklog-void" {
-  team_id    = "${github_team.pkg-committers.id}"
-  repository = "${github_repository.socklog-void.name}"
-  permission = "push"
-}
-
 resource "github_team_repository" "xbps" {
   team_id    = "${github_team.xbps-developers.id}"
   repository = "${github_repository.xbps.name}"
-  permission = "push"
-}
-
-resource "github_team_repository" "xbps-bulk" {
-  team_id    = "${github_team.pkg-committers.id}"
-  repository = "${github_repository.xbps-bulk.name}"
-  permission = "push"
-}
-
-resource "github_team_repository" "netbsd-wtf" {
-  team_id    = "${github_team.pkg-committers.id}"
-  repository = "${github_repository.netbsd-wtf.name}"
-  permission = "push"
-}
-
-resource "github_team_repository" "libglob" {
-  team_id    = "${github_team.pkg-committers.id}"
-  repository = "${github_repository.libglob.name}"
-  permission = "push"
-}
-
-resource "github_team_repository" "jbigkit-shared" {
-  team_id    = "${github_team.pkg-committers.id}"
-  repository = "${github_repository.jbigkit-shared.name}"
-  permission = "push"
-}
-
-resource "github_team_repository" "musl-obstack" {
-  team_id    = "${github_team.pkg-committers.id}"
-  repository = "${github_repository.musl-obstack.name}"
-  permission = "push"
-}
-
-resource "github_team_repository" "musl-fts" {
-  team_id    = "${github_team.pkg-committers.id}"
-  repository = "${github_repository.musl-fts.name}"
-  permission = "push"
-}
-
-resource "github_team_repository" "openbsd-man" {
-  team_id    = "${github_team.pkg-committers.id}"
-  repository = "${github_repository.openbsd-man.name}"
   permission = "push"
 }


### PR DESCRIPTION
Part of #29.  Right now we have a lot of random repositories that pkg-committers has access to. These repositories are generally considered at this point to be read-only, though they still occasionally get patches on them.  In order to apply the principal of least bits, this commit removes a lot of permissions the pkg-committers team previously held. 