### PR TITLE
buildmaster changes

### DIFF
--- a/ansible/roles/buildmaster/templates/master.cfg.j2
+++ b/ansible/roles/buildmaster/templates/master.cfg.j2
@@ -163,7 +163,7 @@ c['status'] = [
 		host='chat.freenode.net',
 		nick='xbps-builder',
 		channels=[{'channel': '#xbps'}],
-		notify_events={ 'finished' : 1 },
+		notify_events={ 'failure' : 1 },
 		noticeOnChannel=True, useRevisions=True
 	)
 ]

--- a/ansible/roles/buildmaster/templates/run.j2
+++ b/ansible/roles/buildmaster/templates/run.j2
@@ -2,4 +2,4 @@
 
 . /{{ buildmaster_rootdir}}/virtual_builder/bin/activate
 
-chpst -u {{ buildmaster_user }}:{{ buildmaster_user }} buildbot start --nodaemon /{{ buildmaster_rootdir }}/buildmaster
+exec chpst -u {{ buildmaster_user }}:{{ buildmaster_user }} buildbot start --nodaemon /{{ buildmaster_rootdir }}/buildmaster


### PR DESCRIPTION
1. make runit supervise buildmaster correctly.
2. the channel was so quiet when the xbps-builder was gone and we don't really need success notifications, failures are all that matters.