### PR TITLE
github_members: remove asergi user.

### DIFF
--- a/terraform/github/github_members.tf
+++ b/terraform/github/github_members.tf
@@ -38,7 +38,6 @@ locals {
         "Vaelatern",
         "abenson",
         "ahesford",
-        "asergi",
         "ericonr",
         "jnbr",
         "leahneukirchen",


### PR DESCRIPTION
Member has been inactive for a long time, removing to prevent any
impacts from possible account highjacking.

---

This is only being done as a preventive measure. If possible, they should stay in the org itself (that's assuming they don't answer here).

@asergi feel free to comment anything.