### PR TITLE
Remove the dead IRC bot from config

### DIFF
--- a/ansible/roles/buildmaster/templates/master.cfg.j2
+++ b/ansible/roles/buildmaster/templates/master.cfg.j2
@@ -158,13 +158,6 @@ c['status'] = [
 					}
 				},
 		change_hook_auth=["file:/{{ buildmaster_rootdir}}/github-webhook.passwd"]
-	),
-	words.IRC(
-		host='chat.freenode.net',
-		nick='xbps-builder',
-		channels=[{'channel': '#xbps'}],
-		notify_events={ 'failure' : 1 },
-		noticeOnChannel=True, useRevisions=True
 	)
 ]
 


### PR DESCRIPTION
This bot has not been used for months now and has been replaced by
void-robot.