### PR TITLE
terraform/github: Remove push access from pullmoll

### DIFF
--- a/terraform/github/github_members.tf
+++ b/terraform/github/github_members.tf
@@ -42,7 +42,6 @@ locals {
         "jnbr",
         "leahneukirchen",
         "lemmi",
-        "pullmoll",
         "q66",
         "sgn",
         "thypon",


### PR DESCRIPTION
Today we received the incredibly sad news that long time contributor
and maintainer Jürgen Buchmüller (pullmoll) has passed away.

As a standard measure of security, the access to any repositories is
being revoked from the account, but pullmoll will remain in the Void
Organization.