### PR TITLE
ansible: special case for cleanup of obsolete multilib packages

### DIFF
--- a/ansible/roles/buildmaster/templates/master.cfg.j2
+++ b/ansible/roles/buildmaster/templates/master.cfg.j2
@@ -84,8 +84,13 @@ for m in user_settings.machines:
 """.format(BootstrapArgs=BootstrapArgs, distdir=distdir, masterdir=masterdir, hostdir=hostdir, subarch=subarch)
 
 	RemoveObsoletes = """
-bash -c 'for repo in {hostdir}/binpkgs {hostdir}/binpkgs/debug {hostdir}/binpkgs/nonfree {hostdir}/binpkgs/multilib {hostdir}/binpkgs/multilib/nonfree ; do XBPS_ARCH={mach} xbps-rindex -r $repo ; done'
+bash -c 'for repo in {hostdir}/binpkgs {hostdir}/binpkgs/debug {hostdir}/binpkgs/nonfree ; do XBPS_ARCH={mach} xbps-rindex -r $repo ; done'
 """.format(distdir=distdir, hostdir=hostdir, mach=m['mach'])
+
+	RemoveObsoletesMultilib = """
+bash -c 'for repo in {hostdir}/binpkgs/multilib {hostdir}/binpkgs/multilib/nonfree ; do XBPS_ARCH=x86_64 xbps-rindex -r $repo ; done'
+""".format(distdir=distdir, hostdir=hostdir)
+
 
 	bulk_conf = ["../%s/configure" % bulkdir,
 			'-a', crosstarget,
@@ -135,12 +140,28 @@ bash -c 'for repo in {hostdir}/binpkgs {hostdir}/binpkgs/debug {hostdir}/binpkgs
 		descriptionDone=["Finished removing obsolete packages"],
 		workdir='.', haltOnFailure=True, usePTY=True, timeout=14400,
 		decodeRC={0:SUCCESS,1:FAILURE,2:FAILURE})
+	remove_obsoletes_multilib_step = ShellCommand(command=RemoveObsoletesMultilib, logEnviron=False,
+		description=["Removing obsolete multilib packages"],
+		descriptionDone=["Finished removing obsolete multilib packages"],
+		workdir='.', haltOnFailure=True, usePTY=True, timeout=14400,
+		decodeRC={0:SUCCESS,1:FAILURE,2:FAILURE})
 
 	m['bulk_factory_steps'] = [
 		bulk_clean_step, git_clean_step, bootinst_step,
 		bootup_step, conf_step, get_pkgs_step, make_step,
 		remove_obsoletes_step
 	]
+
+	# since i686 writes the x86_64 multilib repository,
+	# we have a special case for it to also cleanup the obsolete
+	# packages it is responsible for. This avoids a race condition
+	# where if the x86_64 builder would clean the repo,
+	# when i686 is currently generating the package archives but
+	# has not added them to the index yet in which case they
+	# would be deleted.
+	if m['mach'] == "i686":
+		m['bulk_factory_steps'].append(remove_obsoletes_multilib_step)
+
 	m['bulk_factory'] = BuildFactory(m['bulk_factory_steps'])
 	m['bulk_factory'].useProgress = False
 


### PR DESCRIPTION
The i686 builder is responsible for writing it multilib repos,
therefore it should also be responsible to clean up behind itself
after adding new packages.

Otherwise the x86_64 builder might try to cleanup the multilib
repos between xbps-create and xbps-rindex, which loses the packages.

https://github.com/void-linux/void-packages/issues/30420