### PR TITLE
ignore temporary files created by xbps-create

### DIFF
--- a/services/nomad/build/buildsync-dist.nomad
+++ b/services/nomad/build/buildsync-dist.nomad
@@ -32,8 +32,8 @@ job "buildsync-dist" {
       }
 
       env {
-        CRON_TASK_1="* * * * * flock -n /run/sync.lock rsync -vurk --delete-after -e 'ssh -i /secrets/id_rsa -o UserKnownHostsFile=/local/known_hosts' void-buildsync@a-fsn-de.node.consul:/data/pkgs/ /pkgs/"
-        CRON_TASK_2="* * * * * flock -n /run/srcs.lock rsync -vurk  --delete-after -e 'ssh -i /secrets/id_rsa -o UserKnownHostsFile=/local/known_hosts' void-buildsync@a-fsn-de.node.consul:/hostdir/sources/ /sources/"
+        CRON_TASK_1="* * * * * flock -n /run/sync.lock rsync -vurk --filter '- .*' --delete-after -e 'ssh -i /secrets/id_rsa -o UserKnownHostsFile=/local/known_hosts' void-buildsync@a-fsn-de.node.consul:/data/pkgs/ /pkgs/"
+        CRON_TASK_2="* * * * * flock -n /run/srcs.lock rsync -vurk --delete-after -e 'ssh -i /secrets/id_rsa -o UserKnownHostsFile=/local/known_hosts' void-buildsync@a-fsn-de.node.consul:/hostdir/sources/ /sources/"
       }
 
       resources {


### PR DESCRIPTION
This comes a bit late, but this is the result of an age old tweet where I kept history of packages of the void repo with no clue why

https://twitter.com/__eater__/status/1268876225415647234

Basically `rsync` errors out on the temporary files xbps-create makes, and then refuses to delete the other files.

this _seems_ to be currently happening to the de.alpha, thus motivation to actually make a PR for these changes (I don't claim that's the reason tho)

I tested this with a local rsync daemon and it ignores all those files mentioned in the thread (thus `.plistXXXXX` and `.xbps-pkg-XXXX`)