### PR TITLE
terraform/github: Add paper42 to pkg-committers

### DIFF
--- a/terraform/github/github_members.tf
+++ b/terraform/github/github_members.tf
@@ -40,6 +40,7 @@ locals {
         "ahesford",
         "ericonr",
         "jnbr",
+        "paper42",
         "leahneukirchen",
         "lemmi",
         "q66",


### PR DESCRIPTION
@paper42 please confirm here that you accept this offer of a position on our maintainer team, at which time Duncaen will confirm that this PR is correct.

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with
the following symbols:
  + create

Terraform will perform the following actions:

  # github_team_membership.team_membership["pkg-committers_paper42"] will be created
  + resource "github_team_membership" "team_membership" {
      + etag     = (known after apply)
      + id       = (known after apply)
      + role     = "member"
      + team_id  = "2795568"
      + username = "paper42"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```