### PR TITLE
bulk: replace all git protocol occurrences with https

### DIFF
--- a/ansible/roles/buildmaster/templates/master.cfg.j2
+++ b/ansible/roles/buildmaster/templates/master.cfg.j2
@@ -68,8 +68,8 @@ for m in user_settings.machines:
 	subarch = m['subarch']
 	BootstrapArgs = m['BootstrapArgs']
 
-	xbps_packages_url = 'git://github.com/void-linux/void-packages.git'
-	bulk_url = 'git://github.com/void-linux/xbps-bulk.git'
+	xbps_packages_url = 'https://github.com/void-linux/void-packages.git'
+	bulk_url = 'https://github.com/void-linux/xbps-bulk.git'
 
 	BootstrapZap = """
 {distdir}/xbps-src -m {masterdir} zap

--- a/ansible/roles/void-updates/templates/void_updates.j2
+++ b/ansible/roles/void-updates/templates/void_updates.j2
@@ -1,1 +1,1 @@
-0 4 * * * {{ void_updates_user }} /usr/bin/void-updates -p 20 -r git://github.com/void-linux/void-packages.git -s {{ void_updates_homedir }}/src -o {{ void_updates_homedir }}/result
+0 4 * * * {{ void_updates_user }} /usr/bin/void-updates -p 20 -r https://github.com/void-linux/void-packages.git -s {{ void_updates_homedir }}/src -o {{ void_updates_homedir }}/result

--- a/docs/src/upkeep/images.md
+++ b/docs/src/upkeep/images.md
@@ -32,7 +32,7 @@ Now install the required extra packages:
 Obtain the contents of mklive:
 
 ```
-$ git clone git://github.com/void-linux/void-mklive.git
+$ git clone https://github.com/void-linux/void-mklive.git
 ```
 
 Perform the initial make for templating:


### PR DESCRIPTION
GitHub dropped support for the unauthenticated git protocol
ref: https://github.blog/2021-09-01-improving-git-protocol-security-github/
