### PR TITLE
services/nomad/mirror: default timeout and exclude patterns for rsyncd

### DIFF
--- a/services/nomad/mirror/mirror.nomad
+++ b/services/nomad/mirror/mirror.nomad
@@ -63,6 +63,8 @@ path = /srv/rsync
 read only = yes
 list = yes
 transfer logging = true
+timeout = 600
+exclude = - .* - *-repodata.* - *-stagedata.*
 EOF
         destination = "local/voidmirror.conf"
       }


### PR DESCRIPTION
`rsyncd.conf(5)` default timeout is 0, but suggests 600 (10 minutes) for anonymous rsync daemons, this only kicks in if the client does not define its own timeout.

Exclude patterns so clients don't have to care about it.