### PR TITLE
[RFC] Change repo layout from current/ to packages/<ARCH>/<LIBC>/

### DIFF
--- a/services/nomad/mirror/compat-layout.conf
+++ b/services/nomad/mirror/compat-layout.conf
@@ -1,0 +1,37 @@
+location /current/ {
+    location ~ /current/aarch64/(?<filepath>.*\.aarch64-musl(?:\.xbps(?:\.sig)?|-repodata))$ {
+        alias /packages/aarch64/musl/$filepath;
+    }
+
+    location ~ /current/aarch64/(?<filepath>.*\.aarch64(?:\.xbps(?:\.sig)?|-repodata))$ {
+        alias /packages/aarch64/glibc/$filepath;
+    }
+
+    location ~ /current/musl/(?<filepath>.*\.x86_64-musl(?:\.xbps(?:\.sig)?|-repodata))$ {
+        alias /packages/x86_64/musl/$filepath;
+    }
+
+    location ~ /current/musl/(?<filepath>.*\.armv6l-musl(?:\.xbps(?:\.sig)?|-repodata))$ {
+        alias /packages/armv6l/musl/$filepath;
+    }
+
+    location ~ /current/musl/(?<filepath>.*\.armv7l-musl(?:\.xbps(?:\.sig)?|-repodata))$ {
+        alias /packages/armv7l/musl/$filepath;
+    }
+
+    location ~ /current/(?<filepath>.*\.x86_64(?:\.xbps(?:\.sig)?|-repodata))$ {
+        alias /packages/x86_64/glibc/$filepath;
+    }
+
+    location ~ /current/(?<filepath>.*\.i686(?:\.xbps(?:\.sig)?|-repodata))$ {
+        alias /packages/i686/glibc/$filepath;
+    }
+
+    location ~ /current/(?<filepath>.*\.armv6l(?:\.xbps(?:\.sig)?|-repodata))$ {
+        alias /packages/armv6l/glibc/$filepath;
+    }
+
+    location ~ /current/(?<filepath>.*\.armv7l(?:\.xbps(?:\.sig)?|-repodata))$ {
+        alias /packages/armv7l/glibc/$filepath;
+    }
+}

--- a/services/nomad/mirror/mirror.nomad
+++ b/services/nomad/mirror/mirror.nomad
@@ -34,11 +34,17 @@ job "mirror" {
 
       config {
         image = "ghcr.io/void-linux/infra-nginx:20220804RC02"
+        volumes = ["local/compat-layout.conf:/etc/nginx/locations.d/compat-layout.conf"]
       }
 
       volume_mount {
         volume = "dist-mirror"
         destination = "/srv/www"
+      }
+
+      template {
+        data = file("compat-layout.conf")
+        destination = "local/compat-layout.conf"
       }
     }
 


### PR DESCRIPTION
This is my attempt to implement a new, more predictable repository layout, as previously discussed on IRC.

There are a number of open questions:
- What should the actual layout be? The current implementation goes with `packages/<ARCH>/<LIBC>/`. The other options that I can think of are
    - `packages/<ARCH>-<LIBC>/`
    - `packages/<XBPS_ARCH>/`
    - `packages/<ARCH>/` with glibc and musl combined in the same dir (like the current aarch64 situation)
- This pr does not currently change the layout of subrepos relative to the main one. Should the contents of the main repo for an arch-libc combo also be moved to a `main` subdirectory? `main`, `nonfree`, etc would all be at the same level.
- How should the current mirrors be migrated to the new structure? Would it only be a matter of letting rsync do the job or would a one-time script be needed?

### Todo
- Buildsync
    - [ ] Update to `buildsync-*.nomad` for new paths
        Still a bit nebulous to me how exactly would that be done.
- Mirrors
    - [x] Nginx rules for compatibility with old paths
    - [ ] Testing the rules