### PR TITLE
services/pkg/xmandump/update: dump nonfree packages

### DIFF
--- a/services/pkg/xmandump/update
+++ b/services/pkg/xmandump/update
@@ -3,13 +3,16 @@
 mkdir -p /mirror/man
 cd /mirror/man || exit 1
 
-for arch in x86_64 musl/x86_64-musl armv7l musl/armv7l-musl; do
+archs="x86_64 x86_64-musl armv7l armv7l-musl"
+
+for arch in $archs; do
     printf "Dumping %s\n" "$arch"
-    [ -d "./${arch#musl/}" ] || mkdir ./${arch#musl/}
-    cd ./${arch#musl/} || exit 1
-    xmandump -compress -c cache.json /mirror/current/${arch}-repodata
+    [ -d "./${arch}" ] || mkdir "./${arch}"
+    cd "./${arch}" || exit 1
+    [ "${arch}" != "${arch%-musl}" ] && subdir="musl" || subdir=
+    xmandump -compress -c cache.json "/mirror/current/${subdir}/${arch}-repodata" "/mirror/current/${subdir}/nonfree/${arch}-repodata"
     cd ../ || exit 1
 done
 
 printf "Running makewhatis; this could take a while...\n"
-makewhatis x86_64 x86_64-musl armv7l armv7l-musl
+makewhatis $archs


### PR DESCRIPTION
tested by replacing `xmandump` with `echo`

```
Dumping x86_64
-compress -c cache.json /mirror/current//x86_64-repodata /mirror/current//nonfree/x86_64-repodata
Dumping x86_64-musl
-compress -c cache.json /mirror/current/musl/x86_64-musl-repodata /mirror/current/musl/nonfree/x86_64-musl-repodata
Dumping armv7l
-compress -c cache.json /mirror/current//armv7l-repodata /mirror/current//nonfree/armv7l-repodata
Dumping armv7l-musl
-compress -c cache.json /mirror/current/musl/armv7l-musl-repodata /mirror/current/musl/nonfree/armv7l-musl-repodata
```

closes #87
