### PR TITLE
services/pkg/man-cgi/root.conf: workaround gz links

### DIFF
--- a/services/pkg/man-cgi/root.conf
+++ b/services/pkg/man-cgi/root.conf
@@ -1,3 +1,6 @@
+# workaround .gz being added to links
+rewrite ^(.*)\.gz$ $1 permanent;
+
 location / {
     fastcgi_split_path_info ^(/)(.*)$;
 


### PR DESCRIPTION
a result of hacked-in support for gz in man-cgi, this should be good enough for now.
