### PR TITLE
services/nomad/monitoring: add missing mirrors, update SE mirror urls

### DIFF
--- a/services/nomad/monitoring/prometheus.yml
+++ b/services/nomad/monitoring/prometheus.yml
@@ -253,16 +253,17 @@ scrape_configs:
       arch: [x86_64]
     static_configs:
       - targets:
-        - cdimage.debian.org/mirror/voidlinux/current
-        - ftp.acc.umu.se/mirror/voidlinux/current
         - ftp.debian.ru/mirrors/voidlinux/current
         - ftp.dk.xemacs.org/voidlinux/current
         - ftp.lysator.liu.se/pub/voidlinux/current
-        - ftp.sunet.se/mirror/voidlinux/current
         - ftp.swin.edu.au/voidlinux/current
         - mirror.aarnet.edu.au/pub/voidlinux/current
+        - mirror.accum.se/mirror/voidlinux/current
         - mirror.clarkson.edu/voidlinux/current
+        - mirror.nju.edu.cn/voidlinux/current
         - mirror.ps.kz/voidlinux/current
+        - mirror.puzzle.ch/voidlinux/current
+        - mirror.sjtu.edu.cn/voidlinux/current
         - mirror.vofr.net/voidlinux/current
         - mirror.yandex.ru/mirrors/voidlinux/current
         - mirror2.sandyriver.net/pub/voidlinux/current
@@ -274,8 +275,12 @@ scrape_configs:
         - quantum-mirror.hu/mirrors/pub/voidlinux/current
         - repo-fi.voidlinux.org/current
         - repo-us.voidlinux.org/current
+        - void.chililinux.com/voidlinux/current
         - void.cijber.net/current
+        - void.sakamoto.pl/current
         - void.webconverger.org/current
+        - voidlinux.com.br/repo/current
+        - voidlinux.mirror.garr.it/current
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target


### PR DESCRIPTION
based on:
- void-linux/void-docs#699
- void-linux/void-docs#715
- void-linux/void-docs#724
- void-linux/void-docs#730
