### PR TITLE
New Host: a-fra-de

### DIFF
--- a/ansible/group_vars/prod.yml
+++ b/ansible/group_vars/prod.yml
@@ -19,6 +19,7 @@ void_mesh:
   b-hel-fi.m.voidlinux.org: 192.168.99.113
   a-mci-us.m.voidlinux.org: 192.168.99.114
   b-fsn-de.m.voidlinux.org: 192.168.99.115
+  a-fra-de.m.voidlinux.org: 192.168.99.117
 
 consul_servers:
   - 192.168.99.104

--- a/ansible/host_vars/a-fra-de.m.voidlinux.org.yml
+++ b/ansible/host_vars/a-fra-de.m.voidlinux.org.yml
@@ -1,0 +1,21 @@
+---
+network_static_routes:
+  - to: default
+    via: 212.83.43.1
+  - to: default
+    via: 2a00:f48:2000:1031::1
+
+network_static_interfaces:
+  - name: eno2
+    type: direct
+    addrs:
+      - 212.83.43.28
+      - 2a00:f48:2000:1031::3/64
+
+nomad_host_volumes:
+  - name: dist_mirror
+    path: /data/dist_mirror
+    read_only: false
+
+nomad_meta:
+  mirror_region: de

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -38,6 +38,7 @@ d-sfo3-us.m.voidlinux.org
 e-sfo3-us.m.voidlinux.org
 f-sfo3-us.m.voidlinux.org
 a-mci-us.m.voidlinux.org
+a-fra-de.m.voidlinux.org
 
 [hashi:children]
 hashimaster
@@ -63,6 +64,7 @@ e-sfo3-us.m.voidlinux.org
 [hashimirror]
 b-hel-fi.m.voidlinux.org
 a-mci-us.m.voidlinux.org
+a-fra-de.m.voidlinux.org
 
 [hashimx]
 f-sfo3-us.m.voidlinux.org
@@ -84,10 +86,12 @@ c-sfo3-us.m.voidlinux.org
 d-sfo3-us.m.voidlinux.org
 e-sfo3-us.m.voidlinux.org
 f-sfo3-us.m.voidlinux.org
+a-fra-de.m.voidlinux.org
 
 [musl]
 a-mci-us.m.voidlinux.org
 b-hel-fi.m.voidlinux.org
+a-fra-de.m.voidlinux.org
 
 [net_static]
 a-hel-fi.m.voidlinux.org
@@ -95,3 +99,4 @@ b-hel-fi.m.voidlinux.org
 a-mci-us.m.voidlinux.org
 b-lej-de.m.voidlinux.org
 a-fsn-de.m.voidlinux.org
+a-fra-de.m.voidlinux.org

--- a/terraform/do/dns.tf
+++ b/terraform/do/dns.tf
@@ -329,6 +329,13 @@ resource "digitalocean_record" "repo_ci" {
   value  = "repo-us.voidlinux.org."
 }
 
+resource "digitalocean_record" "repo_de" {
+  domain = digitalocean_domain.voidlinux_org.name
+  type   = "CNAME"
+  name   = "repo-de.${digitalocean_domain.voidlinux_org.name}."
+  value  = "a-fra-de.m.voidlinux.org."
+}
+
 resource "digitalocean_record" "repo_fi" {
   domain = digitalocean_domain.voidlinux_org.name
   type   = "CNAME"

--- a/terraform/do/dns.tf
+++ b/terraform/do/dns.tf
@@ -80,6 +80,20 @@ resource "digitalocean_record" "b_hel_fi_v6" {
   value  = "2a01:4f9:4b:42dc::d01"
 }
 
+resource "digitalocean_record" "a_fra_de" {
+  domain = digitalocean_domain.voidlinux_org.name
+  type   = "A"
+  name   = "a-fra-de.m"
+  value  = "212.83.43.28"
+}
+
+resource "digitalocean_record" "a_fra_de_v6" {
+  domain = digitalocean_domain.voidlinux_org.name
+  type   = "AAAA"
+  name   = "a-fra-de.m"
+  value  = "2a00:f48:2000:1031::3"
+}
+
 resource "digitalocean_record" "a_fsn_de" {
   domain = digitalocean_domain.voidlinux_org.name
   type   = "A"


### PR DESCRIPTION
Host `a-fra-de` is a new host in central Germany being sponsored by [23M](https://23m.com).  Provisioned as a tier 1 mirror with https://repo-de.voidlinux.org pointing at it.