### PR TITLE
remove q66 from pkg-committers

### DIFF
--- a/terraform/github/github_members.tf
+++ b/terraform/github/github_members.tf
@@ -44,7 +44,6 @@ locals {
         "paper42",
         "leahneukirchen",
         "lemmi",
-        "q66",
         "sgn",
         "thypon",
       ]


### PR DESCRIPTION
I have previously decided to resign from the project, and have now reached the point where I do not have any more maintenance left to do.