### PR TITLE
terraform/github: enable discussions on void-packages

### DIFF
--- a/terraform/github/github.tf
+++ b/terraform/github/github.tf
@@ -21,6 +21,7 @@ locals {
       homepage_url       = "https://voidlinux.org"
       allow_merge_commit = false
       allow_squash_merge = false
+      has_discussions    = true
       teams = [
         "pkg-committers",
       ]


### PR DESCRIPTION
closes void-linux/void-packages#43081

Unfortunately, enabling [organization discussions](https://docs.github.com/en/discussions/quickstart#enabling-github-discussions-on-your-organization) (which would put a link to void-packages' discussions on the org page) does not seem be exposed via the API at all currently, so if we want to enable that it will have to be done out-of-band for now.

There will also be some initial setup required for things like categories