### PR TITLE
update containers to new void images, clean up service container CI

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -1,0 +1,27 @@
+name: Build all service containers
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  main:
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - alps
+          - debuginfod
+          - lego
+          - man-cgi
+          - nginx
+          - rspamd
+          - rsync
+          - sftpgo
+          - xmandump
+
+    uses: ./.github/workflows/build-pkg.yml
+    with:
+      service_name: ${{ matrix.service }}

--- a/.github/workflows/build-pkg.yml
+++ b/.github/workflows/build-pkg.yml
@@ -1,0 +1,60 @@
+name: Build Service Container
+on:
+  workflow_call:
+    inputs:
+      service_name:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: classabbyamp/treeless-checkout-action@v1
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/infra-${{ inputs.service_name }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value={{date 'YYYYMMDD'}},enable={{is_default_branch}},priority=1000
+          flavor: latest=false
+          labels: |
+            org.opencontainers.image.authors=Void Linux team and contributors
+            org.opencontainers.image.url=https://voidlinux.org
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.vendor=Void Linux
+            org.opencontainers.image.title=Void Linux infrastructure ${{ inputs.service_name }}
+            org.opencontainers.image.description=infrastructure image for ${{ inputs.service_name }} based on Void Linux
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GCHR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push images
+        id: build_and_push
+        uses: docker/bake-action@v3
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          targets: infra-${{ inputs.service_name }}
+          files: |
+            services/pkg/docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          set: |
+            _common.cache-to=type=gha
+            _common.cache-from=type=gha

--- a/.github/workflows/infradocs.yml
+++ b/.github/workflows/infradocs.yml
@@ -1,34 +1,63 @@
 name: infradocs
 
 on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - docs/**
   push:
     branches:
       - master
     paths:
-      - 'docs/**'
+      - docs/**
 
 jobs:
-  main:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Checkout repo
+        uses: classabbyamp/treeless-checkout-action@v1
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
         with:
-          submodules: false
+          images: |
+            ghcr.io/${{ github.repository_owner }}/infradocs
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+          flavor: latest=false
+          labels: |
+            org.opencontainers.image.authors=Void Linux team and contributors
+            org.opencontainers.image.url=https://voidlinux.org
+            org.opencontainers.image.documentation=https://infradocs.voidlinux.org
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.vendor=Void Linux
+            org.opencontainers.image.title=Void Linux infrastructure documentation
+            org.opencontainers.image.description=infrastructure documentation image for Void Linux
+
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to GCHR
-        uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: void-robot
-          password: ${{ secrets.CR_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
-          push: true
-          tags: "ghcr.io/void-linux/infradocs:${{github.sha}}"
           context: docs
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/pkg-alps.yml
+++ b/.github/workflows/pkg-alps.yml
@@ -1,35 +1,23 @@
 name: alps Service Container
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Version tag"
-        required: true
+  pull_request:
+    branches:
+      - master
+    paths:
+      - services/pkg/alps/**
+  push:
+    branches:
+      - master
+    paths:
+      - services/pkg/alps/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   main:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@master
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to GCHR
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          context: services/pkg/alps
-          push: true
-          tags: "ghcr.io/void-linux/infra-alps:${{ github.event.inputs.version }}"
-          build-args: |
-            ALPS_REV=${{ github.event.inputs.version }}
-          labels: |
-            org.opencontainers.image.source=${{ github.repositoryUrl }}
+    uses: ./.github/workflows/build-pkg.yml
+    with:
+      service_name: alps

--- a/.github/workflows/pkg-lego.yml
+++ b/.github/workflows/pkg-lego.yml
@@ -1,33 +1,23 @@
 name: LEGO Service Container
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Version tag"
-        required: true
+  pull_request:
+    branches:
+      - master
+    paths:
+      - services/pkg/lego/**
+  push:
+    branches:
+      - master
+    paths:
+      - services/pkg/lego/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   main:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@master
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to GCHR
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          context: services/pkg/lego
-          push: true
-          tags: "ghcr.io/void-linux/infra-lego:${{ github.event.inputs.version }}"
-          labels: |
-            org.opencontainers.image.source=${{ github.repositoryUrl }}
+    uses: ./.github/workflows/build-pkg.yml
+    with:
+      service_name: lego

--- a/.github/workflows/pkg-man-cgi.yml
+++ b/.github/workflows/pkg-man-cgi.yml
@@ -1,33 +1,23 @@
 name: man-cgi Service Container
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Version tag"
-        required: true
+  pull_request:
+    branches:
+      - master
+    paths:
+      - services/pkg/man-cgi/**
+  push:
+    branches:
+      - master
+    paths:
+      - services/pkg/man-cgi/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   main:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@master
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to GCHR
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          context: services/pkg/man-cgi
-          push: true
-          tags: "ghcr.io/void-linux/infra-man-cgi:${{ github.event.inputs.version }}"
-          labels: |
-            org.opencontainers.image.source=${{ github.repositoryUrl }}
+    uses: ./.github/workflows/build-pkg.yml
+    with:
+      service_name: man-cgi

--- a/.github/workflows/pkg-nginx.yml
+++ b/.github/workflows/pkg-nginx.yml
@@ -1,33 +1,23 @@
 name: NGINX Service Container
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Version tag"
-        required: true
+  pull_request:
+    branches:
+      - master
+    paths:
+      - services/pkg/nginx/**
+  push:
+    branches:
+      - master
+    paths:
+      - services/pkg/nginx/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   main:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@master
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to GCHR
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          context: services/pkg/nginx
-          push: true
-          tags: "ghcr.io/void-linux/infra-nginx:${{ github.event.inputs.version }}"
-          labels: |
-            org.opencontainers.image.source=${{ github.repositoryUrl }}
+    uses: ./.github/workflows/build-pkg.yml
+    with:
+      service_name: nginx

--- a/.github/workflows/pkg-rspamd.yml
+++ b/.github/workflows/pkg-rspamd.yml
@@ -1,33 +1,23 @@
 name: rspamd Service Container
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Version tag"
-        required: true
+  pull_request:
+    branches:
+      - master
+    paths:
+      - services/pkg/rspamd/**
+  push:
+    branches:
+      - master
+    paths:
+      - services/pkg/rspamd/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   main:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@master
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to GCHR
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          context: services/pkg/rspamd
-          push: true
-          tags: "ghcr.io/void-linux/infra-rspamd:${{ github.event.inputs.version }}"
-          labels: |
-            org.opencontainers.image.source=${{ github.repositoryUrl }}
+    uses: ./.github/workflows/build-pkg.yml
+    with:
+      service_name: rspamd

--- a/.github/workflows/pkg-rsync.yml
+++ b/.github/workflows/pkg-rsync.yml
@@ -1,33 +1,23 @@
 name: RSync Service Container
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Version tag"
-        required: true
+  pull_request:
+    branches:
+      - master
+    paths:
+      - services/pkg/rsync/**
+  push:
+    branches:
+      - master
+    paths:
+      - services/pkg/rsync/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   main:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@master
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to GCHR
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          context: services/pkg/rsync
-          push: true
-          tags: "ghcr.io/void-linux/infra-rsync:${{ github.event.inputs.version }}"
-          labels: |
-            org.opencontainers.image.source=${{ github.repositoryUrl }}
+    uses: ./.github/workflows/build-pkg.yml
+    with:
+      service_name: rsync

--- a/.github/workflows/pkg-sftpgo.yml
+++ b/.github/workflows/pkg-sftpgo.yml
@@ -1,33 +1,23 @@
 name: SFTPGo Service Container
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Version tag"
-        required: true
+  pull_request:
+    branches:
+      - master
+    paths:
+      - services/pkg/sftpgo/**
+  push:
+    branches:
+      - master
+    paths:
+      - services/pkg/sftpgo/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   main:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@master
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to GCHR
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          context: services/pkg/sftpgo
-          push: true
-          tags: "ghcr.io/void-linux/infra-sftpgo:${{ github.event.inputs.version }}"
-          labels: |
-            org.opencontainers.image.source=${{ github.repositoryUrl }}
+    uses: ./.github/workflows/build-pkg.yml
+    with:
+      service_name: sftpgo

--- a/.github/workflows/pkg-xmandump.yml
+++ b/.github/workflows/pkg-xmandump.yml
@@ -1,33 +1,23 @@
 name: xmandump Service Container
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Version tag"
-        required: true
+  pull_request:
+    branches:
+      - master
+    paths:
+      - services/pkg/xmandump/**
+  push:
+    branches:
+      - master
+    paths:
+      - services/pkg/xmandump/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   main:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@master
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to GCHR
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          context: services/pkg/xmandump
-          push: true
-          tags: "ghcr.io/void-linux/infra-xmandump:${{ github.event.inputs.version }}"
-          labels: |
-            org.opencontainers.image.source=${{ github.repositoryUrl }}
+    uses: ./.github/workflows/build-pkg.yml
+    with:
+      service_name: xmandump

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -4,7 +4,6 @@ COPY . .
 RUN mdbook build
 
 FROM busybox:stable
-LABEL org.opencontainers.image.source https://github.com/void-linux/void-infrastructure
 WORKDIR /web
 COPY --from=build /book/book .
 ENTRYPOINT ["/bin/busybox", "httpd", "-f", "-p", "8080"]

--- a/services/pkg/alps/Dockerfile
+++ b/services/pkg/alps/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/void-linux/void-linux:latest-full-x86_64-musl as build
+FROM ghcr.io/void-linux/void-musl-full:latest as build
 ARG ALPS_REV=master
 WORKDIR /alps
 RUN xbps-install -Suy xbps && xbps-install -y git go ca-certificates curl tar file && \

--- a/services/pkg/debuginfod/Dockerfile
+++ b/services/pkg/debuginfod/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/void-linux/void-linux:20210312rc01-mini-bb-x86_64-musl
+FROM ghcr.io/void-linux/void-musl-busybox:latest
 RUN xbps-install -Sy debuginfod && \
         rm -rf /var/cache/xbps
 WORKDIR /debuginfod

--- a/services/pkg/docker-bake.hcl
+++ b/services/pkg/docker-bake.hcl
@@ -1,0 +1,66 @@
+target "docker-metadata-action" {}
+
+target "_common" {
+  inherits = ["docker-metadata-action"]
+  dockerfile = "Dockerfile"
+  no-cache-filter = ["bootstrap"]
+  cache-to = ["type=local,dest=/tmp/buildx-cache"]
+  cache-from = ["type=local,src=/tmp/buildx-cache"]
+}
+
+target "_common-glibc" {
+  inherits = ["_common"]
+  platforms = ["linux/amd64", "linux/386", "linux/arm64", "linux/arm/v7", "linux/arm/v6"]
+  args = { "LIBC" = "glibc" }
+}
+
+target "_common-musl" {
+  inherits = ["_common"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/arm/v6"]
+  args = { "LIBC" = "musl" }
+}
+
+target "infra-alps" {
+  inherits = ["_common-musl"]
+  context = "services/pkg/alps/"
+}
+
+target "infra-debuginfod" {
+  inherits = ["_common-musl"]
+  context = "services/pkg/debuginfod/"
+}
+
+target "infra-lego" {
+  inherits = ["_common-glibc"]
+  context = "services/pkg/lego/"
+}
+
+target "infra-man-cgi" {
+  inherits = ["infra-nginx"]
+  context = "services/pkg/man-cgi/"
+}
+
+target "infra-nginx" {
+  inherits = ["_common-glibc"]
+  context = "services/pkg/nginx/"
+}
+
+target "infra-rspamd" {
+  inherits = ["_common-musl"]
+  context = "services/pkg/rspamd/"
+}
+
+target "infra-rsync" {
+  inherits = ["_common-glibc"]
+  context = "services/pkg/rsync/"
+}
+
+target "infra-sftpgo" {
+  inherits = ["_common-glibc"]
+  context = "services/pkg/sftpgo/"
+}
+
+target "infra-xmandump" {
+  inherits = ["_common-glibc"]
+  context = "services/pkg/xmandump/"
+}

--- a/services/pkg/lego/Dockerfile
+++ b/services/pkg/lego/Dockerfile
@@ -1,4 +1,4 @@
-FROM  ghcr.io/void-linux/void-linux:latest-thin-x86_64
+FROM  ghcr.io/void-linux/void-glibc:latest
 
 RUN xbps-install -Sy && xbps-install -y lego vault binutils upx findutils diffutils && \
         strip /usr/bin/vault /usr/bin/lego && \

--- a/services/pkg/nginx/Dockerfile
+++ b/services/pkg/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM  ghcr.io/void-linux/void-linux:latest-full-x86_64
+FROM  ghcr.io/void-linux/void-glibc-full:latest
 
 RUN xbps-install -Suy xbps && xbps-install -Sy nginx tini
 

--- a/services/pkg/rspamd/Dockerfile
+++ b/services/pkg/rspamd/Dockerfile
@@ -1,4 +1,4 @@
-FROM  ghcr.io/void-linux/void-linux:latest-full-x86_64-musl
+FROM  ghcr.io/void-linux/void-musl-full:latest
 
 RUN xbps-install -Suy xbps && xbps-install -y rspamd tini
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/services/pkg/rsync/Dockerfile
+++ b/services/pkg/rsync/Dockerfile
@@ -1,4 +1,4 @@
-FROM  ghcr.io/void-linux/void-linux:latest-thin-x86_64
+FROM  ghcr.io/void-linux/void-glibc:latest
 
 RUN xbps-install -Sy rsync tini snooze && \
         mkdir -p /etc/rsyncd.conf.d/ && \

--- a/services/pkg/sftpgo/Dockerfile
+++ b/services/pkg/sftpgo/Dockerfile
@@ -1,4 +1,4 @@
-FROM  ghcr.io/void-linux/void-linux:latest-thin-x86_64
+FROM  ghcr.io/void-linux/void-glibc:latest
 
 RUN xbps-install -Syu xbps && xbps-install -Sy tini sftpgo NetAuth-sftpgo-hook
 

--- a/services/pkg/xmandump/Dockerfile
+++ b/services/pkg/xmandump/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/void-linux/void-linux:latest-full-x86_64
+FROM ghcr.io/void-linux/void-glibc-full:latest
 
 RUN xbps-install -Suy xbps && xbps-install -y xmandump mdocml tini && \
 	rm -rf /var/cache/xbps


### PR DESCRIPTION
this should make it easier to ensure that all infra packages are built the same. also takes advantage of the docker metadata action and updates the other actions used.

https://docs.github.com/en/actions/using-workflows/reusing-workflows

[example here](https://github.com/classabbyamp/void-infrastructure/actions/runs/5707269599)