### PR TITLE
services/nomad/monitoring/prometheus.yml: fix typo

### DIFF
--- a/services/nomad/monitoring/prometheus.yml
+++ b/services/nomad/monitoring/prometheus.yml
@@ -146,7 +146,7 @@ scrape_configs:
     metrics_path: /probe
     scrape_interval: 2m
     params:
-      arch: [x86_4-musl]
+      arch: [x86_64-musl]
     static_configs:
       - targets:
           - root-pkgs-internal.service.consul/musl


### PR DESCRIPTION
this has been bothering me when looking at https://grafana.voidlinux.org/d/5w8Ft0UGk/internal-repository-status?orgId=1&refresh=1m
