### PR TITLE
shadow rsyncd

### DIFF
--- a/services/nomad/build/build-rsyncd.nomad
+++ b/services/nomad/build/build-rsyncd.nomad
@@ -73,10 +73,6 @@ transfer logging = true
 timeout = 600
 incoming chmod = D0755,F0644
 
-[shadow]
-path = /hostdir
-exclude = - *-repodata.* - *-stagedata.* - .*
-
 [sources]
 path = /hostdir/sources
 auth users = buildsync-*:rw

--- a/services/nomad/mirror/shadow-rsyncd.nomad
+++ b/services/nomad/mirror/shadow-rsyncd.nomad
@@ -1,0 +1,65 @@
+job "shadow-rsyncd" {
+  type = "service"
+  datacenters = ["VOID"]
+  namespace = "mirror"
+
+  group "rsync" {
+    count = 1
+    network {
+      mode = "bridge"
+      port "rsync" {
+        to = 873
+        host_network = "internal"
+      }
+    }
+
+    volume "glibc_hostdir" {
+      type = "host"
+      source = "glibc_hostdir"
+      read_only = true
+    }
+
+    service {
+      provider = "nomad"
+      name = "shadow-rsyncd"
+      port = "rsync"
+    }
+
+    task "rsyncd" {
+      driver = "docker"
+
+      config {
+        image = "ghcr.io/void-linux/infra-rsync:20230815"
+        volumes = [ "local/shadowsync.conf:/etc/rsyncd.conf.d/shadowsync.conf" ]
+      }
+
+      volume_mount {
+        volume = "glibc_hostdir"
+        destination = "/hostdir"
+      }
+
+      template {
+        data = file("xbps-clean-sigs")
+        destination = "local/xbps-clean-sigs"
+        perms = "0755"
+      }
+
+      template {
+        data = <<EOF
+[global]
+uid = 992
+gid = 991
+read only = yes
+list = yes
+transfer logging = true
+timeout = 600
+
+[shadow]
+path = /hostdir
+exclude = - *-repodata.* - *-stagedata.* - .*
+EOF
+        destination = "local/shadowsync.conf"
+      }
+    }
+  }
+}

--- a/services/nomad/mirror/sync.nomad
+++ b/services/nomad/mirror/sync.nomad
@@ -34,9 +34,20 @@ job "sync" {
           "--timeout", "15",
           "--contimeout", "5",
           "--links",
-          "rsync://a-fsn-de.node.consul/shadow/",
+          "rsync://$RSYNC_ADDR/shadow/",
           "/mirror/",
         ]
+      }
+
+      template {
+        data=<<EOF
+{{ $allocID := env "NOMAD_ALLOC_ID" -}}
+{{ range nomadService 1 $allocID "shadow-rsyncd" }}
+RSYNC_ADDR="{{ .Address }}:{{ .Port }}"
+{{ end }}
+EOF
+        destination = "local/env"
+        env = true
       }
 
       resources {


### PR DESCRIPTION
- services/nomad/build/build-rsyncd: don't serve shadow from this rsyncd
- services/nomad/mirror/shadow-rsyncd: split from build-rsyncd
- services/nomad/mirror/sync: use dynamic service lookup for shadow
