### PR TITLE
services/nomad/build/build-rsyncd: filter out .* *.part

### DIFF
--- a/services/nomad/build/build-rsyncd.nomad
+++ b/services/nomad/build/build-rsyncd.nomad
@@ -75,6 +75,7 @@ incoming chmod = D0755,F0644
 
 [sources]
 path = /hostdir/sources
+filter = - .* - *.part
 auth users = buildsync-*:rw
 
 [aarch64]


### PR DESCRIPTION
these should probably not be grabbed

example:
![image](https://github.com/void-linux/void-infrastructure/assets/5366828/45b9a16d-ae05-4712-be1f-e8e240e0064e)
