### PR TITLE
services/nomad/build/xbps-clean-sigs: fix signature cleanup

### DIFF
--- a/services/nomad/build/xbps-clean-sigs
+++ b/services/nomad/build/xbps-clean-sigs
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 # Remove signatures that don't have a corresponding package.
-find /pkgs \( -name '*.xbps.sig' -o -name '*.xbps.sig2' \) -exec sh -c 'for x in "$@"; do [ -e "${x%.sig*}" ] || rm -- $x; done' _ {} +
+find /hostdir/binpkgs \( -name '*.xbps.sig' -o -name '*.xbps.sig2' \) -exec sh -c 'for x in "$@"; do [ -e "${x%.sig*}" ] || rm -- $x; done' _ {} +
 
 exit 0


### PR DESCRIPTION
the path to look for stale signatures in was changed
