### PR TITLE
ansible/roles/buildmaster/defaults/main.yml: make subarch explicit

### DIFF
--- a/ansible/roles/buildmaster/defaults/main.yml
+++ b/ansible/roles/buildmaster/defaults/main.yml
@@ -8,7 +8,7 @@ buildmaster_rootdir: /home/void-buildmaster/
 buildmaster_machmap:
   x86_64:
     cross: native
-    subarch:
+    subarch: x86_64
   x86_64-musl:
     cross: native-x86_64-musl
     subarch: x86_64-musl


### PR DESCRIPTION
`xbps-src -A <nothing>` fails
