### PR TITLE
popcorn: migrate to nomad

### DIFF
--- a/ansible/host_vars/d-hel-fi.m.voidlinux.org.yml
+++ b/ansible/host_vars/d-hel-fi.m.voidlinux.org.yml
@@ -25,6 +25,9 @@ nomad_host_volumes:
   - name: devspace_home
     path: /data/devspace/home
     read_only: true
+  - name: popcorn_data
+    path: /data/popcorn
+    read_only: false
 
 nomad_meta:
   mirror_region: fi

--- a/services/nomad/apps/popcorn-report.nomad
+++ b/services/nomad/apps/popcorn-report.nomad
@@ -1,0 +1,62 @@
+job "popcorn-report" {
+  datacenters = ["VOID-MIRROR"]
+  namespace = "apps"
+  type = "batch"
+
+  periodic {
+    crons = ["@daily"]
+    prohibit_overlap = true
+  }
+
+  group "report" {
+    count = 1
+
+    network { mode = "bridge" }
+
+    volume "popcorn_data" {
+      type = "host"
+      source = "popcorn_data"
+      read_only = false
+    }
+
+    task "report" {
+      driver = "docker"
+
+      config {
+        image = "ghcr.io/void-linux/infra-popcorn:20240704R1"
+        command = "/local/popcorn-report"
+      }
+
+      volume_mount {
+        volume = "popcorn_data"
+        destination = "/data"
+      }
+
+      env {
+        OUTDIR = "/data"
+      }
+
+      template {
+        data = <<EOF
+#!/bin/sh
+{{ range service "popcorn-statrepo" }}
+exec popcornctl --server "{{ .Address }}" --port "{{ .Port }}" \
+    report --reset --key "${POPCORN_KEY}" --file "${OUTDIR}/popcorn_$(date +%F).json"
+{{ end }}
+EOF
+        destination = "local/popcorn-report"
+        perms = "755"
+      }
+
+      template {
+        data = <<EOF
+{{- with nomadVar "nomad/jobs/popcorn" -}}
+POPCORN_KEY={{.reset_key}}
+{{- end -}}
+EOF
+        destination = "secrets/env"
+        env = true
+      }
+    }
+  }
+}

--- a/services/nomad/apps/popcorn.nomad
+++ b/services/nomad/apps/popcorn.nomad
@@ -1,0 +1,124 @@
+job "popcorn" {
+  datacenters = ["VOID-MIRROR"]
+  namespace = "apps"
+  type = "service"
+
+  group "popcorn" {
+    count = 1
+
+    network {
+      mode = "bridge"
+      port "statrepo" { static = 8001 }
+      port "pqueryd" { static = 8003 }
+      port "http" { to = 80 }
+    }
+
+    volume "popcorn_data" {
+      type = "host"
+      source = "popcorn_data"
+      read_only = false
+    }
+
+    service {
+      name = "popcorn-statrepo"
+      port = "statrepo"
+    }
+
+    task "statrepo" {
+      driver = "docker"
+
+      config {
+        image = "ghcr.io/void-linux/infra-popcorn:20240704R1"
+        command = "statrepo"
+        args = [
+          "--port", "${NOMAD_PORT_statrepo}",
+          "--reset_key", "${POPCORN_KEY}",
+        ]
+        ports = ["statrepo"]
+      }
+
+      template {
+                data = <<EOF
+{{- with nomadVar "nomad/jobs/popcorn" -}}
+POPCORN_KEY={{.reset_key}}
+{{- end -}}
+EOF
+        destination = "secrets/env"
+        env = true
+      }
+
+      volume_mount {
+        volume = "popcorn_data"
+        destination = "/var/lib/popcorn"
+      }
+    }
+
+    service {
+      name = "popcorn-pqueryd"
+      port = "pqueryd"
+    }
+
+    task "pqueryd" {
+      driver = "docker"
+
+      config {
+        image = "ghcr.io/void-linux/infra-popcorn:20240704R1"
+        command = "pqueryd"
+        args = [
+          "--checkpoint_enabled=false",
+          "--port", "${NOMAD_PORT_pqueryd}",
+          "--data_dir", "/data",
+        ]
+      }
+
+      resources {
+        memory = 8000
+      }
+
+      volume_mount {
+        volume = "popcorn_data"
+        destination = "/data"
+        read_only = true
+      }
+    }
+
+    service {
+      name = "popcorn"
+      port = "http"
+      meta {
+        nginx_enable = "true"
+        nginx_names = "popcorn.voidlinux.org"
+      }
+    }
+
+    task "nginx" {
+      driver = "docker"
+
+      config {
+        image = "ghcr.io/void-linux/infra-nginx:20230812"
+      }
+
+      template {
+        data = <<EOF
+server {
+    server_name popcorn;
+    listen 0.0.0.0:80 default_server;
+
+    root /srv/www;
+
+    location / {
+        autoindex on;
+    }
+}
+EOF
+        destination = "local/nginx/popcorn.conf"
+      }
+
+      volume_mount {
+        volume = "popcorn_data"
+        destination = "/srv/www"
+        read_only = true
+      }
+    }
+  }
+}

--- a/terraform/hashistack/policy_popcorn.tf
+++ b/terraform/hashistack/policy_popcorn.tf
@@ -1,0 +1,19 @@
+resource "nomad_acl_policy" "popcorn_admin" {
+  name = "popcorn-admin"
+  description = "Manage popcorn keys in nomad variables"
+
+  job_acl {
+    namespace = "apps"
+    job_id = "popcorn-report"
+  }
+
+  rules_hcl = <<EOT
+namespace "apps" {
+  variables {
+    path "nomad/jobs/popcorn" {
+      capabilities = ["read"]
+    }
+  }
+}
+EOT
+}


### PR DESCRIPTION
this leaves only buildbot outside of nomad, I think.

should be deployed/merged in parts:

1. ~~merge and build container (and update the tag in nomad)~~
2. apply addition of popcorn host volume in ansible
3. copy all popcorn data from the current location to the volume
4. decommission ansible-based popcorn
5. run the nomad jobs

testing:
- ran all components in concert in docker (manually), which worked perfectly
- ran `nomad job plan` for each job (failed to place because the host volume doesn't exist yet, but no other errors)

fixes #76 

![image](https://github.com/void-linux/void-infrastructure/assets/5366828/2e742b90-118e-42ec-93b6-5480bf1df156)
