### PR TITLE
terraform/do/dns: rehome popcorn to d-hel-fi

### DIFF
--- a/terraform/do/dns.tf
+++ b/terraform/do/dns.tf
@@ -326,6 +326,13 @@ resource "digitalocean_record" "netauth" {
   value  = "a-sfo3-us.m.${digitalocean_domain.voidlinux_org.name}."
 }
 
+resource "digitalocean_record" "popcorn" {
+  domain = digitalocean_domain.voidlinux_org.name
+  type   = "CNAME"
+  name   = "popcorn"
+  value  = "d-hel-fi.m.${digitalocean_domain.voidlinux_org.name}."
+}
+
 resource "digitalocean_record" "www" {
   domain = digitalocean_domain.voidlinux_org.name
   type   = "A"


### PR DESCRIPTION
Revert "terraform/do/dns: popcorn is served by omniproxy"

This reverts commit 57d2007e998af39eef12696d179920559471edb6.
