### PR TITLE
nomadic buildbot

### DIFF
--- a/docs/src/services/buildbot.md
+++ b/docs/src/services/buildbot.md
@@ -2,13 +2,13 @@
 
 BuildBot is our legacy build scheduler.
 
-The buildbot master runs at
+The buildbot controller runs at
 [build.voidlinux.org](https://build.voidlinux.org) and provides
 unified scheduling to all other build tasks in the fleet.  BuildBot
 also exposes a web interface.
 
 The current status of the build infrastructure can be found on the
-build waterfall.  This view shows what each of the buildslaves is
+build waterfall.  This view shows what each of the builders is
 doing right now, and uses traffic light colors for build state.  A
 purple builder is usually a reason to contact void-ops and figure out
 what's wrong with the build host.
@@ -18,18 +18,44 @@ failed without needing to push a new commit.  Not all committers have
 access to restart failed builds this way.  If you believe that you
 should have this access, contact maldridge@.
 
-## Moving a buildslave
+## Moving a builder
 
-Don't.
+First, all builds need to be paused until the move can be completed.
+Builders must be moved in the groups they currently are in (glibc, musl,
+and aarch64). Sync the hostdir host volume to the new location, then
+migrate the nomad job to the new host.
 
-In the event that this is unavoidable, all builds need to be paused
-until the move can be completed.  In the even the builder that needs
-to be moved is on the musl cluster, all musl builders will need to be
-moved with it.  Similarly, the aarch64 builders must always move as a
-pair.
+## Updating buildbot
+
+The buildbot controller and builders should be kept at the same buildbot
+version.
+
+1. Update the buildbot version in both the `buildbot` and
+   `buildbot-builder` Dockerfiles.
+2. Rebuild the service containers by triggering a build for the
+   `infra-buildbot` and `infra-buildbot-builder` containers in CI.
+3. Update the nomad jobs to use the new containers and restart them
+   with the task meta variable `db-upgrade = "true"`. This will run
+   any necessary migrations on startup.
+4. Re-set `db-upgrade = "false"`. The job does not need to be
+   redeployed, but on the next deployment, it will not run the upgrade.
+
+## Future Plans
+
+Buildbot 4 uses the database to store logs. Currently, we are using the sqlite
+backend. If this causes performance issues in the future, we should switch to
+[postgres](https://docs.buildbot.net/current/manual/deploy.html#using-a-database-server).
+To migrate the database from sqlite, the steps appear to be:
+
+1. Ensure the sqlite database is fully upgraded by running the controller task with
+   `db-upgrade = "true"`.
+2. Set up a postgres server with a buildbot user (see Buildbot's documentation linked
+   above).
+3. Run `buildbot copydb postgres://buildbot:passw0rd@ip/buildbot /path/to/buildbot/basedir`.
+4. Update the buildbot configuration to use the new database url.
 
 ## EOL
 
-BuildBot is slated for replacement this fall/winter.  The system will
-be replaced by the Distributed XBPS Package Builder (dxpb) which will
-resolve many of the long standing problems in the buildbot.
+BuildBot is slated for replacement in the future.  The system will
+be replaced by the Distributed XBPS Package Builder (dxpb) or nbuild
+which will resolve many of the long standing problems in the buildbot.

--- a/services/nomad/build/buildbot-worker.nomad
+++ b/services/nomad/build/buildbot-worker.nomad
@@ -1,0 +1,139 @@
+job "buildbot-worker" {
+  type = "service"
+  datacenters = ["VOID"]
+  namespace = "build"
+
+  dynamic "group" {
+    for_each = [
+      // memory is ~85% of capacity
+      { name = "glibc",   jobs = 10, mem = 109512 },
+      { name = "musl",    jobs = 6,  mem = 54512  },
+      { name = "aarch64", jobs = 3,  mem = 27256  },
+    ]
+    labels = [ "buildbot-worker-${group.value.name}" ]
+
+    content {
+      network {
+        mode = "bridge"
+        hostname = "void-buildbot-worker-${group.value.name}"
+      }
+
+      dynamic "volume" {
+        for_each = [ "${group.value.name}" ]
+        labels = [ "${volume.value}_hostdir" ]
+
+        content {
+          type = "host"
+          source = "${volume.value}_hostdir"
+          read_only = false
+        }
+      }
+
+      // https://github.com/hashicorp/nomad/issues/8892
+      task "prep-hostdir" {
+        driver = "docker"
+
+        config {
+          image = "ghcr.io/void-linux/void-glibc-full:20240526R1"
+          command = "chown"
+          args = ["-R", "418:418", "/hostdir"]
+        }
+
+        volume_mount {
+          volume = "${group.value.name}_hostdir"
+          destination = "/hostdir"
+        }
+
+        lifecycle {
+          hook = "prestart"
+        }
+      }
+
+      task "buildbot-worker" {
+        driver = "docker"
+
+        user = "void-builder"
+
+        config {
+          image = "ghcr.io/void-linux/infra-buildbot-builder:20240928R1"
+          force_pull = true
+          cap_add = ["sys_admin"]
+        }
+
+        resources {
+          cores = "${group.value.jobs}"
+          memory = "${group.value.mem}"
+        }
+
+        volume_mount {
+          volume = "${group.value.name}_hostdir"
+          destination = "/hostdir"
+        }
+
+        template {
+          data = <<EOF
+{{ range service "buildbot-worker" -}}
+[buildbot]
+host = {{ .Address }}
+worker-port = {{ .Port }}
+{{ end -}}
+
+[worker]
+name = worker-${group.value.name}
+EOF
+          destination = "local/config.ini"
+        }
+
+        template {
+          data = <<EOF
+XBPS_MAKEJOBS=${group.value.jobs}
+XBPS_CHROOT_CMD=uchroot
+XBPS_CHROOT_CMD_ARGS='-t'
+XBPS_CCACHE=yes
+XBPS_DEBUG_PKGS=yes
+XBPS_USE_GIT_REVS=yes
+XBPS_DISTFILES_MIRROR=https://sources.voidlinux.org
+XBPS_PRESERVE_PKGS=yes
+EOF
+          destination = "local/xbps-src.conf"
+        }
+
+        template {
+          data = "Void Build Operators <build-ops@voidlinux.org>"
+          destination = "local/info/admin"
+        }
+
+        template {
+          data = <<EOF
+Void Linux Buildbot builder for ${group.value.name} running on {{ env "attr.unique.hostname" -}}
+EOF
+          destination = "local/info/host"
+        }
+
+        template {
+          data = <<EOF
+{{- with nomadVar "nomad/jobs/buildbot-worker" -}}
+{{ .worker_password }}
+{{- end -}}
+EOF
+          destination = "secrets/buildbot/worker-password"
+          perms = "400"
+          uid = 418
+          gid = 418
+        }
+
+        template {
+          data = <<EOF
+{{- with nomadVar "nomad/jobs/buildsync" -}}
+{{ .${group.value.name}_password }}
+{{- end -}}
+EOF
+          destination = "secrets/rsync/password"
+          perms = "400"
+          uid = 418
+          gid = 418
+        }
+      }
+    }
+  }
+}

--- a/services/nomad/build/buildbot.cfg
+++ b/services/nomad/build/buildbot.cfg
@@ -1,0 +1,368 @@
+# vim: set ft=python:
+
+# {{ $allocID := env "NOMAD_ALLOC_ID" }}
+
+import configparser
+import json
+import shlex
+from pathlib import Path
+
+from twisted.internet import defer
+
+from buildbot.process.results import SUCCESS, SKIPPED
+from buildbot.plugins import util, secrets, reporters, worker, schedulers
+from buildbot.plugins import steps
+
+ini = configparser.ConfigParser()
+ini.read('/local/config.ini')
+
+with open(ini['buildbot'].get('workers', '/local/workers.json')) as f:
+    js = json.load(f)
+    workers = js.get("workers", [])
+    builders = js.get("builders", [])
+
+netauth = util.BuildbotNetAuth(conf=Path("/etc/netauth/config.toml"))
+
+authz = util.Authz(
+    allowRules=[
+        util.AnyEndpointMatcher(role="ops", defaultDeny=False),
+        util.AnyControlEndpointMatcher(role="ops"),
+    ],
+    roleMatchers=[
+        util.RolesFromGroups(groupPrefix="build-"),
+    ]
+)
+
+c = BuildmasterConfig = {
+    'buildbotNetUsageData': None,
+    'protocols': {'pb': {'port': ini['buildbot'].getint('worker-port', 9989)}},
+    'secretsProviders': [secrets.SecretInAFile(dirname="/secrets/buildbot")],
+    'workers': [],
+    'change_source': [],
+    'collapseRequests': True,
+    'schedulers': [],
+    'builders': [],
+    'services': [reporters.Prometheus(port=9100)],
+    'title': ini['buildbot'].get('title', 'Void Linux'),
+    'titleURL': ini['buildbot'].get('title-url', 'https://voidlinux.org/'),
+    'buildbotURL': ini['buildbot'].get('url', 'http://localhost:8010/'),
+    'www': {
+        'port': ini['buildbot'].getint('www-port', 8010),
+        'plugins': {'waterfall_view': {}, 'console_view': {}, 'grid_view': {}, 'void_view': {}},
+        'change_hook_dialects': {
+            'github': {
+                'secret': util.Secret('github-webhook'),
+                'strict': True,
+            },
+        },
+        'avatar_methods': [
+            netauth, util.AvatarGitHub(), util.AvatarGravatar(),
+        ],
+        'authz': authz,
+        'auth': netauth,
+        'ui_default_config': {
+            'Links.build_link_template': "%(build_number)",
+            'Waterfall.number_background_waterfall': True,
+            'Waterfall.show_builders_without_builds': True,
+            'Builders.show_workers_name': True,
+            'Grid.fullChanges': True,
+        },
+    },
+    'db': {
+        'db_url': ini['buildbot'].get('db-url', 'sqlite:////db/state.sqlite'),
+    },
+}
+
+if 'irc' in ini:
+    c['services'].append(reporters.IRC(
+        host=ini['irc']['host'],
+        port=ini['irc'].getint('port', 6697),
+        nick=ini['irc']['nick'],
+        password=util.Secret('irc-password'),
+        channels=[ini['irc']['channel']],
+        authz={'!': ini['irc'].get('authz-users', '').split(' ')},
+        notify_events=ini['irc'].get(
+            'notify-events', 'failure exception cancelled worker'
+        ).split(),
+        noticeOnChannel=ini['irc'].getboolean('notice', True),
+        # useRevisions and showBlameList are not implemented and will cause
+        # the irc notifier to error out, do NOT enable them
+        useRevisions=ini['irc'].getboolean('use-revisions', False),
+        showBlameList=ini['irc'].getboolean('show-blame', False),
+        useSSL=ini['irc'].getboolean('use-ssl', True),
+        useColors=ini['irc'].getboolean('use-colors', True),
+    ))
+
+# ###### WORKERS
+
+for w in workers:
+    name = 'worker-' + w['name']
+    passwd = util.Secret('worker-password')
+    max_builds = w.get('max-builds', 1)
+    c['workers'].append(worker.Worker(name, passwd, max_builds=max_builds))
+
+
+# ###### SCHEDULERS
+
+builder_names = []
+for b in builders:
+    builder_names.append(b['name'])
+
+c['schedulers'].append(schedulers.SingleBranchScheduler(
+    name="all",
+    change_filter=util.ChangeFilter(branch='master'),
+    treeStableTimer=None,
+    builderNames=builder_names))
+
+c['schedulers'].append(schedulers.ForceScheduler(
+    name="force",
+    builderNames=builder_names))
+
+
+# ###### BUILDERS
+
+distdir = 'void-packages'
+bulkdir = 'xbps-bulk'
+hostdir = '/hostdir'
+buildroot = 'buildroot'
+builddir = lambda: util.Interpolate('builddir-%(prop:buildnumber)s')
+do_sync = lambda: util.Interpolate('%(prop:sync)s') == "True"
+hide_skipped = lambda results, _: results == SKIPPED
+
+
+factory = util.BuildFactory()
+
+
+@util.renderer
+def make_xbps_src_cmd(props, cmd):
+    command = [
+        f'{distdir}/xbps-src',
+        '-H', hostdir,
+        '-m', buildroot,
+        '-A', props.getProperty('host'),
+    ]
+
+    if cmd == 'binary-bootstrap':
+        command += shlex.split(str(props.getProperty('bootstrap_args')))
+    elif props.getProperty('cross') == 'True':
+        command += ['-a', props.getProperty('target')]
+
+    command += [cmd]
+
+    return command
+
+
+@util.renderer
+def make_xbps_bulk_cmd(props):
+    command = [
+        f'../{bulkdir}/configure',
+        '-h', hostdir,
+        '-d', f'../{distdir}',
+        '-m', f'../{buildroot}',
+        '-t',
+    ]
+    if props.getProperty('cross') == 'True':
+        command += ['-a', props.getProperty('target')]
+    else:
+        command += ['-a', 'native-', props.getProperty('host')]
+
+    return command
+
+
+class ShellCommandWithChanges(steps.ShellCommand):
+    @defer.inlineCallbacks
+    def run(self):
+        cmd = yield self.makeRemoteShellCommand()
+        pkgs = [f.split("/")[-2] for f in self.build.allFiles()
+            if f.startswith("srcpkgs/") and f.endswith("/template")]
+        cmd.command += pkgs
+        yield self.runCommand(cmd)
+        return cmd.results()
+
+
+@util.renderer
+def build_packages(props):
+    # if a better solver is written
+    # cmds = []
+    # for p in str(props.getProperty('packages')).strip().split():
+    #     cmds.append(util.ShellArg(
+    #         command=['make', f'built/{p}'],
+    #         logname=f'pkg:{p}',
+    #         haltOnFailure=True,
+    #     ))
+    cmds = [util.ShellArg(
+        command=['make', 'all'],
+        logname='build',
+        haltOnFailure=True,
+    )]
+    if cmds:
+        cmds.append(util.ShellArg(
+            command=['make', 'clean'],
+            logname='cleanup',
+            haltOnFailure=True,
+        ))
+    return cmds
+
+
+@util.renderer
+def make_prune_cmd(props):
+    return ['bash', '-c',
+            util.Interpolate(f"""
+export XBPS_TARGET_ARCH="%(prop:target)s"
+for repo in / /debug /nonfree /bootstrap; do
+    xbps-rindex -r "{hostdir}/binpkgs/$repo"
+done
+if [ "$XBPS_TARGET_ARCH" = i686 ]; then
+    for repo in /multilib /multilib/nonfree /multilib/bootstrap; do
+        XBPS_TARGET_ARCH=x86_64 xbps-rindex -r "{hostdir}/binpkgs/$repo"
+    done
+fi
+""")]
+
+@util.renderer
+def make_rsync_cmd(props):
+    return ['bash', '-c',
+            util.Interpolate("""
+rsync -vurk --delete-after --delay-updates \
+--filter='+ */ + %(prop:target)s-repodata + %(prop:target)s-stagedata + *.%(prop:target)s.xbps + otime - .* - *' \
+--password-file=/secrets/rsync/password /hostdir/binpkgs/ \
+{{ range nomadService 1 $allocID "build-rsyncd" -}}
+rsync://buildsync-%(prop:worker)s@{{ .Address }}:{{ .Port }}/%(prop:worker)s
+{{ end -}}""")]
+
+
+factory.addStep(steps.Git(
+    repourl='https://github.com/void-linux/void-packages.git',
+    mode='incremental',
+    workdir=distdir,
+    progress=True,
+    alwaysUseLatest=True,
+    name='update_void_packages',
+    description='updating void-packages from git',
+    descriptionDone='void-packages updated',
+    haltOnFailure=True,
+    logEnviron=False,
+))
+
+factory.addStep(steps.Git(
+    repourl='https://github.com/void-linux/xbps-bulk.git',
+    mode='incremental',
+    workdir=bulkdir,
+    progress=True,
+    alwaysUseLatest=True,
+    name='update_xbps_bulk',
+    description='updating xbps-bulk from git',
+    descriptionDone='xbps-bulk updated',
+    haltOnFailure=True,
+    logEnviron=False,
+))
+
+factory.addStep(steps.ShellCommand(
+    command=make_xbps_src_cmd.withArgs('binary-bootstrap'),
+    name='bootstrap',
+    description='running xbps-src binary-bootstrap',
+    descriptionDone='xbps-src binary-bootstrap done',
+    haltOnFailure=True,
+    logEnviron=False,
+    usePTY=True,
+    workdir='.',
+))
+
+factory.addStep(steps.ShellCommand(
+    command=make_xbps_src_cmd.withArgs('bootstrap-update'),
+    name='bootstrap_update',
+    description='updating xbps-src bootstrap packages',
+    descriptionDone='xbps-src bootstrap-update done',
+    haltOnFailure=True,
+    logEnviron=False,
+    usePTY=True,
+    workdir='.',
+))
+
+factory.addStep(ShellCommandWithChanges(
+    command=make_xbps_bulk_cmd,
+    name='find_packages',
+    description='finding packages to build',
+    descriptionDone='found packages',
+    haltOnFailure=True,
+    logEnviron=False,
+    usePTY=True,
+    workdir=builddir(),
+))
+
+factory.addStep(steps.SetPropertyFromCommand(
+    command=['make', 'print_pkgs'],
+    property='packages',
+    name='get_packages',
+    description='collecting packages to build',
+    descriptionDone='collected packages',
+    haltOnFailure=True,
+    logEnviron=False,
+    workdir=builddir(),
+))
+
+factory.addStep(steps.ShellSequence(
+    commands=build_packages,
+    name='build_packages',
+    description='building packages',
+    descriptionDone='built packages',
+    haltOnFailure=True,
+    logEnviron=False,
+    usePTY=True,
+    workdir=builddir(),
+    timeout=14400,
+))
+
+factory.addStep(steps.ShellCommand(
+    command=make_prune_cmd,
+    name='prune_packages',
+    description='removing obsolete packages',
+    descriptionDone='removed obsolete packages',
+    haltOnFailure=True,
+    logEnviron=False,
+    usePTY=True,
+    workdir='.',
+    timeout=14400,
+))
+
+factory.addStep(steps.ShellCommand(
+    command=make_rsync_cmd,
+    name='sync_packages',
+    description='syncing packages to the shadow repository',
+    descriptionDone='synced packages to the shadow repository',
+    alwaysRun=True,
+    logEnviron=False,
+    usePTY=True,
+    workdir='.',
+    doStepIf=do_sync(),
+    hideStepIf=hide_skipped,
+    timeout=14400,
+    decodeRC={
+        0: SUCCESS,
+        23: SUCCESS,
+        24: SUCCESS,
+    },
+))
+
+for b in builders:
+    workernames = ["worker-" + b['worker']]
+
+    name = b['name']
+    hostarch = b['host']
+    targetarch = b.get('target', hostarch)
+    props = {
+        'name': name,
+        'host': hostarch,
+        'target': targetarch,
+        'cross': str(hostarch != targetarch),
+        'worker': b['worker'],
+        'sync': str(b['sync']),
+        'bootstrap_args': b.get('bootstrap_args', '-N'),
+    }
+
+    c['builders'].append(util.BuilderConfig(
+        name=name,
+        workernames=workernames,
+        factory=factory,
+        properties=props,
+    ))

--- a/services/nomad/build/buildbot.nomad
+++ b/services/nomad/build/buildbot.nomad
@@ -1,0 +1,164 @@
+job "buildbot" {
+  type = "service"
+  datacenters = ["VOID"]
+  namespace = "build"
+
+  group "buildbot" {
+    network {
+      mode = "bridge"
+      hostname = "void-buildbot"
+
+      port "http" {
+        static = 8010
+        to = 8010
+      }
+
+      port "metrics" { to = 9100 }
+
+      port "worker" {
+        to = 42042
+        host_network = "internal"
+      }
+    }
+
+    volume "buildbot_database" {
+      type = "host"
+      source = "buildbot_database"
+      read_only = false
+    }
+
+    volume "netauth_config" {
+      type = "host"
+      read_only = true
+      source = "netauth_config"
+    }
+
+    service {
+      name = "buildbot-www"
+      port = "http"
+
+      check {
+        type = "http"
+        address_mode = "host"
+        path = "/"
+        timeout = "30s"
+        interval = "5s"
+      }
+    }
+
+    service {
+      name = "buildbot-worker"
+      port = "worker"
+    }
+
+    service {
+        name = "buildbot-metrics"
+        port = "metrics"
+    }
+
+    task "buildbot" {
+      driver = "docker"
+
+      config {
+        image = "ghcr.io/void-linux/infra-buildbot:20240928R1"
+        force_pull = true
+        ports = ["http", "worker"]
+      }
+
+      meta {
+        // set to "true" to create or upgrade the database when starting
+        db-upgrade = "false"
+      }
+
+      volume_mount {
+        volume = "buildbot_database"
+        destination = "/db"
+      }
+
+      volume_mount {
+        volume = "netauth_config"
+        destination = "/etc/netauth"
+        read_only = true
+      }
+
+      template {
+        data = <<EOF
+[buildbot]
+worker-port = 42042
+url = https://build.voidlinux.org/
+
+[irc]
+host = irc.libera.chat
+nick = void-builder
+channel = #xbps
+authz = duncaen maldridge abby
+EOF
+        destination = "local/config.ini"
+      }
+
+      template {
+        data = jsonencode({
+          workers = [
+            { name = "glibc",   max-builds = 4 },
+            { name = "musl",    max-builds = 3 },
+            { name = "aarch64", max-builds = 2 },
+          ],
+          builders = [
+            { name = "x86_64",       host = "x86_64",                               worker = "glibc",   sync = false                     },
+            { name = "i686",         host = "i686",                                 worker = "glibc",   sync = false                     },
+            { name = "armv7l",       host = "x86_64",      target = "armv7l",       worker = "glibc",   sync = false                     },
+            { name = "armv6l",       host = "x86_64",      target = "armv6l",       worker = "glibc",   sync = false                     },
+            { name = "x86_64-musl",  host = "x86_64-musl",                          worker = "musl",    sync = true                      },
+            { name = "armv7l-musl",  host = "x86_64-musl", target = "armv7l-musl",  worker = "musl",    sync = true                      },
+            { name = "armv6l-musl",  host = "x86_64-musl", target = "armv6l-musl",  worker = "musl",    sync = true                      },
+            { name = "aarch64",      host = "x86_64",      target = "aarch64",      worker = "aarch64", sync = true, bootstrap_args = "" },
+            { name = "aarch64-musl", host = "x86_64-musl", target = "aarch64-musl", worker = "aarch64", sync = true, bootstrap_args = "" },
+          ],
+        })
+        destination = "local/workers.json"
+      }
+
+      template {
+        data = file("buildbot.cfg")
+        destination = "local/buildbot.cfg"
+      }
+
+      template {
+        data = <<EOF
+Void Linux Buildbot controller running on {{ env "attr.unique.hostname" -}}
+EOF
+        destination = "local/info/host"
+      }
+
+      template {
+        data = <<EOF
+{{- with nomadVar "nomad/jobs/buildbot" -}}
+{{ .webhook_secret }}
+{{- end -}}
+EOF
+        destination = "secrets/buildbot/github-webhook"
+        perms = "400"
+      }
+
+      template {
+        data = <<EOF
+{{- with nomadVar "nomad/jobs/buildbot" -}}
+{{ .irc_password }}
+{{- end -}}
+EOF
+        destination = "secrets/buildbot/irc-password"
+        perms = "400"
+      }
+
+      template {
+        data = <<EOF
+{{- with nomadVar "nomad/jobs/buildbot-worker" -}}
+{{ .worker_password }}
+{{- end -}}
+EOF
+        destination = "secrets/buildbot/worker-password"
+        perms = "400"
+      }
+    }
+  }
+}

--- a/services/nomad/infrastructure/nginx-mirror.nomad
+++ b/services/nomad/infrastructure/nginx-mirror.nomad
@@ -62,7 +62,8 @@ job "nginx" {
           "10-mirror.conf",
           "10-proxy.conf",
           "10-sources.conf",
-          "10-wiki.conf"
+          "10-wiki.conf",
+          "10-buildbot.conf",
         ]
 
         content {

--- a/services/nomad/infrastructure/nginx-sites/10-buildbot.conf
+++ b/services/nomad/infrastructure/nginx-sites/10-buildbot.conf
@@ -1,0 +1,30 @@
+server {
+    include /etc/nginx/fragments/ssl.conf;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name build.voidlinux.org;
+
+    proxy_set_header HOST $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Server $host;
+    proxy_set_header X-Forwarded-Host $host;
+
+    location / {
+        proxy_pass http://buildbot-www.service.consul:8010/;
+    }
+
+    location /sse/ {
+        proxy_buffering off;
+        proxy_pass http://buildbot-www.service.consul:8010/sse/;
+    }
+
+    location /ws {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $http_connection;
+        proxy_pass http://buildbot-www.service.consul:8010/ws;
+        proxy_read_timeout 6000s;
+    }
+}

--- a/services/nomad/monitoring/prometheus.yml
+++ b/services/nomad/monitoring/prometheus.yml
@@ -268,3 +268,8 @@ scrape_configs:
     relabel_configs:
       - source_labels: ['__meta_consul_node']
         target_label: instance
+  - job_name: buildbot
+    consul_sd_configs:
+      - server: {{ env "NOMAD_HOST_IP_http" }}:8500
+        datacenter: void
+        services: ['buildbot-metrics']


### PR DESCRIPTION
TODOs:

- [x] auth
- [x] remove various TODOs in code
- [x] test
- [x] make a replacement for btimefiles - #202 
- [x] fix the irc bot notifications
- [x] split off containers - #210
- [x] database host volume - #209

closes #133 

![buildbot-nomad](https://github.com/user-attachments/assets/1e265a61-309c-48ba-83fa-3a0c1a2656bb)

## secrets changes

### buildsync

need to migrate secrets from vault to nomad:
```
secret/buildsync/aarch64 -> nomad/jobs/buildsync .aarch64_password
secret/buildsync/musl -> nomad/jobs/buildsync .musl_password
```

### buildbot
create/migrate secrets:
```
nomad/jobs/buildbot
    .webhook_secret
    .irc_password
nomad/jobs/buildbot-worker
    .worker_password
```
