### PR TITLE
btimefiles nomad

### DIFF
--- a/ansible/roles/btimefiles/tasks/main.yml
+++ b/ansible/roles/btimefiles/tasks/main.yml
@@ -1,24 +1,16 @@
 ---
-- name: Install Service (1/2)
-  file:
-    path: /etc/sv/btimefiles
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
-
-- name: Install Service (2/2)
-  copy:
-    src: run
-    dest: /etc/sv/btimefiles/run
-    owner: root
-    group: root
-    mode: 0755
-  notify:
-    - btimefiles
-
-- name: Enable Service
+- name: Disable Service
   runit:
     name: btimefiles
-    state: started
-    enabled: true
+    enabled: false
+
+- name: Uninstall Service (1/2)
+  file:
+    path: /etc/sv/btimefiles/run
+    state: absent
+
+- name: Uninstall Service (2/2)
+  file:
+    path: /etc/sv/btimefiles
+    state: absent
+

--- a/services/nomad/build/timefiles.nomad
+++ b/services/nomad/build/timefiles.nomad
@@ -1,0 +1,56 @@
+job "timefiles" {
+  type = "service"
+  datacenters = ["VOID"]
+  namespace = "build"
+
+  dynamic "group" {
+    for_each = [ "glibc", "aarch64", "musl", ]
+    labels = [ "timefiles-${group.value}" ]
+
+    content {
+      count = 1
+      network { mode = "bridge" }
+
+      dynamic "volume" {
+        for_each = [ "${group.value}" ]
+        labels = [ "${volume.value}_hostdir" ]
+
+        content {
+          type = "host"
+          source = "${volume.value}_hostdir"
+          read_only = false
+        }
+      }
+
+      task "timefiles" {
+        driver = "docker"
+
+        config {
+          image = "ghcr.io/void-linux/void-glibc:20240526R1"
+          command = "/local/run.sh"
+        }
+
+        volume_mount {
+          volume = "${group.value}_hostdir"
+          destination = "/hostdir"
+        }
+
+        template {
+          data = <<EOF
+#!/bin/sh
+
+while true ; do
+    t="$(date +%s)"
+    for dir in / /nonfree /debug /multilib /multilib/nonfree /nonfree ; do
+        echo "$t">"/hostdir/binpkgs/$dir/otime"
+    done
+    sleep 60
+done
+EOF
+          destination = "local/run.sh"
+          perms = "0755"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
working towards buildbot in nomad

should be cleaned up on the ansible side first, then the nomad job can deployed

tested on my local nomad setup, everything works:

![image](https://github.com/user-attachments/assets/b29e74b8-9ef7-4de5-8d66-8daf14392e64)

```
$ fd otime /hostdir -x sh -c 'echo $0; cat $0'
/hostdir/musl/binpkgs/debug/otime
1720983637
/hostdir/aarch64/binpkgs/debug/otime
1720983637
/hostdir/musl/binpkgs/otime
1720983637
/hostdir/musl/binpkgs/nonfree/otime
1720983637
/hostdir/aarch64/binpkgs/nonfree/otime
1720983637
/hostdir/glibc/binpkgs/debug/otime
1720983637
/hostdir/glibc/binpkgs/otime
1720983637
/hostdir/aarch64/binpkgs/otime
1720983637
/hostdir/glibc/binpkgs/multilib/otime
1720983637
/hostdir/glibc/binpkgs/nonfree/otime
1720983637
/hostdir/glibc/binpkgs/multilib/nonfree/otime
1720983637
$ fd otime /hostdir -x sh -c 'echo $0; cat $0'
/hostdir/musl/binpkgs/debug/otime
1720984117
/hostdir/musl/binpkgs/otime
1720984117
/hostdir/musl/binpkgs/nonfree/otime
1720984117
/hostdir/glibc/binpkgs/nonfree/otime
1720984117
/hostdir/aarch64/binpkgs/otime
1720984117
/hostdir/glibc/binpkgs/multilib/nonfree/otime
1720984117
/hostdir/glibc/binpkgs/multilib/otime
1720984117
/hostdir/aarch64/binpkgs/nonfree/otime
1720984117
/hostdir/glibc/binpkgs/debug/otime
1720984117
/hostdir/aarch64/binpkgs/debug/otime
1720984117
/hostdir/glibc/binpkgs/otime
1720984117
```
