### PR TITLE
add basic editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{hcl,nomad,tf,yml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
enforces some basic style guidelines tree-wide and in yaml/hcl files

mostly adding this because i'm annoyed at my editor trying to do 4-space indents in hcl files

open to changing this/adding more filetypes
