### PR TITLE
various rsync improvements

### DIFF
--- a/services/nomad/build/build-rsyncd.nomad
+++ b/services/nomad/build/build-rsyncd.nomad
@@ -81,7 +81,7 @@ auth users = buildsync-*:rw
 [aarch64]
 path = /hostdir/binpkgs/aarch64
 auth users = buildsync-aarch64:rw
-filter = + */ + *-repodata + otime + *.xbps - *.sig - *.sig2 - *-repodata.* - *-stagedata.* - .*
+filter = + */ + *-repodata + otime + *.xbps - *.sig - *.sig2 - *-repodata.* - *-stagedata.* - *.x86_64* - .*
 post-xfer exec = /local/xbps-clean-sigs
 
 [musl]

--- a/services/nomad/build/build-rsyncd.nomad
+++ b/services/nomad/build/build-rsyncd.nomad
@@ -37,6 +37,10 @@ job "build-rsyncd" {
         volumes = [ "local/buildsync.conf:/etc/rsyncd.conf.d/buildsync.conf" ]
       }
 
+      resources {
+        memory = 1000
+      }
+
       volume_mount {
         volume = "glibc_hostdir"
         destination = "/hostdir"

--- a/services/nomad/build/buildsync.nomad
+++ b/services/nomad/build/buildsync.nomad
@@ -76,7 +76,7 @@ sync {
         update = true,
         copy_dirlinks = true,
         password_file = "/secrets/rsync_passwd",
-        _extra = { "--delete-after" },
+        _extra = { "--delete-after", "--delay-updates" },
     }
 }
 
@@ -92,7 +92,7 @@ sync {
         update = true,
         copy_dirlinks = true,
         password_file = "/secrets/rsync_passwd",
-        _extra = { "--delete-after" },
+        _extra = { "--delete-after", "--delay-updates" },
     }
 }
 EOF

--- a/services/nomad/mirror/sync.nomad
+++ b/services/nomad/mirror/sync.nomad
@@ -36,6 +36,7 @@ job "sync" {
           args = [
             "-vurk",
             "--delete-after",
+            "--delay-updates",
             "--links",
             "rsync://${env["RSYNC_ADDR"]}/${group.value}/",
             "/${group.value}/",


### PR DESCRIPTION
- **services/nomad/build/build-rsyncd: ignore x86_64 packages in /aarch64/**
- **services/nomad/build/build-rsyncd: increase memory limit**
- **services/nomad/build/buildsync: --delay-updates**
- **services/nomad/mirror/sync: --delay-updates**

a few changes that should hopefully improve things
