### PR TITLE
services/nomad/mirror/shadow-rsyncd: increase memory limit

### DIFF
--- a/services/nomad/build/build-rsyncd.nomad
+++ b/services/nomad/build/build-rsyncd.nomad
@@ -85,7 +85,7 @@ auth users = buildsync-*:rw
 [aarch64]
 path = /hostdir/binpkgs/aarch64
 auth users = buildsync-aarch64:rw
-filter = + */ + *-repodata + otime + *.xbps - *.sig - *.sig2 - *-repodata.* - *-stagedata.* - *.x86_64* - .*
+filter = + */ + *-repodata + otime + *.xbps - *.sig - *.sig2 - *-repodata.* - *-stagedata.* - *.x86_64* - x86_64*-repodata - .*
 post-xfer exec = /local/xbps-clean-sigs
 
 [musl]

--- a/services/nomad/mirror/shadow-rsyncd.nomad
+++ b/services/nomad/mirror/shadow-rsyncd.nomad
@@ -39,6 +39,10 @@ job "shadow-rsyncd" {
         volumes = [ "local/shadowsync.conf:/etc/rsyncd.conf.d/shadowsync.conf" ]
       }
 
+      resources {
+        memory = 1000
+      }
+
       volume_mount {
         volume = "root_mirror"
         destination = "/mirror"


### PR DESCRIPTION
is OOMing, seems to be causing the missing repodata issue
