### PR TITLE
don't sync by_sha256 sources

### DIFF
--- a/services/nomad/build/build-rsyncd.nomad
+++ b/services/nomad/build/build-rsyncd.nomad
@@ -38,7 +38,7 @@ job "build-rsyncd" {
       }
 
       resources {
-        memory = 1000
+        memory = 1500
       }
 
       volume_mount {
@@ -79,7 +79,7 @@ incoming chmod = D0755,F0644
 
 [sources]
 path = /hostdir/sources
-filter = - .* - *.part
+filter = - by_sha256/ - .* - *.part
 auth users = buildsync-*:rw
 
 [aarch64]

--- a/services/nomad/mirror/shadow-rsyncd.nomad
+++ b/services/nomad/mirror/shadow-rsyncd.nomad
@@ -69,7 +69,7 @@ exclude = - *-repodata.* - *-stagedata.* - .*
 
 [sources]
 path = /hostdir/sources
-exclude = - .*
+exclude = - by_sha256/ - .*
 EOF
         destination = "local/shadowsync.conf"
       }


### PR DESCRIPTION
not sure why this started happening recently.

these are hardlinks and get dereferenced, leading to duplicate data on the mirrors and wasted space. this may have been causing some of the issues with repodatas going missing.

**this changeset has been deployed**
