### PR TITLE
buildbot ansible

### DIFF
--- a/ansible/group_vars/buildworker.yml
+++ b/ansible/group_vars/buildworker.yml
@@ -1,0 +1,5 @@
+---
+# Running xbps-src with xbps-uchroot and overlayfs within a container
+# requires CAP_SYS_ADMIN to be able to mount the overlay
+nomad_extra_caps:
+  - sys_admin

--- a/ansible/hashi-worker.yml
+++ b/ansible/hashi-worker.yml
@@ -116,3 +116,10 @@
         - "-A INPUT -p tcp --dport 587 -j ACCEPT"
         - "-A INPUT -p tcp --dport 993 -j ACCEPT"
         - "COMMIT"
+
+- hosts: buildworker
+  become: yes
+  become_user: root
+  become_method: sudo
+  roles:
+    - buildworker

--- a/ansible/host_vars/h-hel-fi.m.voidlinux.org.yml
+++ b/ansible/host_vars/h-hel-fi.m.voidlinux.org.yml
@@ -11,3 +11,8 @@ network_static_interfaces:
     addrs:
       - 65.21.145.134/32
       - 2a01:4f9:c012:8db::2/64
+
+nomad_host_volumes:
+  - name: buildbot_database
+    path: /data/buildbot
+    read_only: false

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -10,6 +10,11 @@ b-fsn-de.m.voidlinux.org
 buildmaster
 buildslave
 
+[buildworker]
+a-hel-fi.m.voidlinux.org
+a-fsn-de.m.voidlinux.org
+b-fsn-de.m.voidlinux.org
+
 [root_mirror]
 a-fsn-de.m.voidlinux.org
 

--- a/ansible/roles/buildworker/defaults/main.yml
+++ b/ansible/roles/buildworker/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+# Default user to run buildbot workers under
+buildworker_user: _void-builder
+
+# Additional groups for the buildworker user.  At minimum this must
+# contain xbuilder for the chroot to work correctly within xbps-src
+buildworker_groups:
+  - xbuilder
+
+# uid/gid for buildbot worker user
+buildworker_uid: 418
+buildworker_gid: 418

--- a/ansible/roles/buildworker/tasks/main.yml
+++ b/ansible/roles/buildworker/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: create buildbot worker primary group ({{ buildworker_user }})
+  group:
+    name: "{{ buildworker_user }}"
+    gid: "{{ buildworker_gid }}"
+    system: yes
+
+- name: Create buildbot worker user ({{ buildworker_user }})
+  user:
+    name: "{{ buildworker_user }}"
+    state: present
+    create_home: no
+    system: yes
+    uid: "{{ buildworker_uid }}"
+    group: "{{ buildworker_user }}"
+    groups: "{{ buildworker_groups | join(',') }}"
+
+- name: Install sudo policy
+  template:
+    src: buildworker.sudoers.j2
+    dest: /etc/sudoers.d/buildworker
+    owner: root
+    group: root
+    mode: 0640

--- a/ansible/roles/buildworker/templates/buildworker.sudoers.j2
+++ b/ansible/roles/buildworker/templates/buildworker.sudoers.j2
@@ -1,0 +1,1 @@
+%build-ops ALL=({{ buildworker_user }}) ALL

--- a/ansible/roles/nomad-client/templates/40-client.hcl
+++ b/ansible/roles/nomad-client/templates/40-client.hcl
@@ -56,5 +56,6 @@ vault {
 plugin "docker" {
   config {
     extra_labels = ["*"]
+    allow_caps = {{ ( nomad_default_caps + ( nomad_extra_caps | default([]) ) ) | to_json }}
   }
 }

--- a/ansible/roles/nomad-client/vars/main.yml
+++ b/ansible/roles/nomad-client/vars/main.yml
@@ -1,0 +1,16 @@
+---
+# from https://developer.hashicorp.com/nomad/docs/drivers/docker#allow_caps
+nomad_default_caps:
+  - audit_write
+  - chown
+  - dac_override
+  - fowner
+  - fsetid
+  - kill
+  - mknod
+  - net_bind_service
+  - setfcap
+  - setgid
+  - setpcap
+  - setuid
+  - sys_chroot


### PR DESCRIPTION
- **ansible/roles/nomad-client: support adding docker caps**: to run xbps-src in docker in nomad without using the ephemeral chroot method, we need to give the container `CAP_SYS_ADMIN`. this makes that possible.
- **ansible/roles/buildworker: new role**: does basic setup for the buildworker user on the buildworker hosts. this should work in parallel to the current buildslave group and setup. (it's mostly a clone of that role)
- **ansible/host_vars/h-hel-fi: add buildbot controller volume**: this is for the buildbot database
