### PR TITLE
buildbot sync/terraform changes

### DIFF
--- a/services/nomad/build/build-rsyncd.nomad
+++ b/services/nomad/build/build-rsyncd.nomad
@@ -28,10 +28,6 @@ job "build-rsyncd" {
     task "rsyncd" {
       driver = "docker"
 
-      vault {
-        policies = ["void-secrets-buildsync"]
-      }
-
       config {
         image = "ghcr.io/void-linux/infra-rsync:20240709R1"
         volumes = [ "local/buildsync.conf:/etc/rsyncd.conf.d/buildsync.conf" ]
@@ -54,12 +50,10 @@ job "build-rsyncd" {
 
       template {
         data = <<EOF
-{{- with secret "secret/buildsync/aarch64" -}}
-buildsync-aarch64:{{.Data.password}}
-{{ end }}
-{{- with secret "secret/buildsync/musl" -}}
-buildsync-musl:{{.Data.password}}
-{{ end }}
+{{- with nomadVar "nomad/jobs/buildsync" }}
+buildsync-aarch64:{{ .aarch64_password }}
+buildsync-musl:{{ .musl_password }}
+{{- end }}
 EOF
         destination = "secrets/buildsync.secrets"
         perms = "0400"
@@ -68,8 +62,8 @@ EOF
       template {
         data = <<EOF
 [global]
-uid = 992
-gid = 991
+uid = 418
+gid = 418
 secrets file = /secrets/buildsync.secrets
 read only = yes
 list = yes

--- a/terraform/do/dns.tf
+++ b/terraform/do/dns.tf
@@ -360,13 +360,6 @@ resource "digitalocean_record" "d_sfo3_us" {
 # just CNAMEs onto other machines defined above.                      #
 #######################################################################
 
-resource "digitalocean_record" "build" {
-  domain = digitalocean_domain.voidlinux_org.name
-  type   = "CNAME"
-  name   = "build"
-  value  = "a-hel-fi.m.${digitalocean_domain.voidlinux_org.name}."
-}
-
 resource "digitalocean_record" "devspace" {
   domain = digitalocean_domain.voidlinux_org.name
   type   = "CNAME"

--- a/terraform/hashistack/policy_buildbot.tf
+++ b/terraform/hashistack/policy_buildbot.tf
@@ -1,0 +1,19 @@
+resource "nomad_acl_policy" "buildbot_worker_admin" {
+  name = "buildbot-worker-admin"
+  description = "Manage buildbot worker secrets in nomad variables"
+
+  job_acl {
+    namespace = "build"
+    job_id = "buildbot"
+  }
+
+  rules_hcl = <<EOT
+namespace "build" {
+  variables {
+    path "nomad/jobs/buildbot-worker" {
+      capabilities = ["read"]
+    }
+  }
+}
+EOT
+}

--- a/terraform/hashistack/policy_buildsync.tf
+++ b/terraform/hashistack/policy_buildsync.tf
@@ -4,12 +4,27 @@ resource "nomad_acl_policy" "buildsync_admin" {
 
   job_acl {
     namespace = "build"
-    job_id = "buildbot-worker"
+    job_id = "build-rsyncd"
   }
+
+  rules_hcl = <<EOT
+namespace "build" {
+  variables {
+    path "nomad/jobs/buildsync" {
+      capabilities = ["read"]
+    }
+  }
+}
+EOT
+}
+
+resource "nomad_acl_policy" "buildsync_buildbot_admin" {
+  name = "buildsync-buildbot-admin"
+  description = "Manage buildsync secrets in nomad variables for buildbot"
 
   job_acl {
     namespace = "build"
-    job_id = "build-rsyncd"
+    job_id = "buildbot-worker"
   }
 
   rules_hcl = <<EOT

--- a/terraform/hashistack/policy_buildsync.tf
+++ b/terraform/hashistack/policy_buildsync.tf
@@ -1,13 +1,24 @@
-data "vault_policy_document" "secrets_buildsync" {
-  rule {
-    path         = "secret/buildsync/*"
-    capabilities = ["read"]
-    description  = "Read secrets associated with build repo sync"
+resource "nomad_acl_policy" "buildsync_admin" {
+  name = "buildsync-admin"
+  description = "Manage buildsync secrets in nomad variables"
+
+  job_acl {
+    namespace = "build"
+    job_id = "buildbot-worker"
+  }
+
+  job_acl {
+    namespace = "build"
+    job_id = "build-rsyncd"
+  }
+
+  rules_hcl = <<EOT
+namespace "build" {
+  variables {
+    path "nomad/jobs/buildsync" {
+      capabilities = ["read"]
+    }
   }
 }
-
-resource "vault_policy" "secrets_buildsync" {
-  name   = "void-secrets-buildsync"
-  policy = data.vault_policy_document.secrets_buildsync.hcl
+EOT
 }
-


### PR DESCRIPTION
- **services/nomad/build/build-rsyncd: use nomad variables for secrets**
- **services/nomad/build/buildsync: use nomad vars, only sync sources**
- **terraform/hashistack: add buildbot worker nomad var policy**

split from #198

## secrets changes

### buildsync

need to migrate secrets from vault to nomad:
```
secret/buildsync/aarch64 -> nomad/jobs/buildsync .aarch64_password
secret/buildsync/musl -> nomad/jobs/buildsync .musl_password
```

### buildbot
create/migrate secrets:
```
nomad/jobs/buildbot
    .webhook_secret
    .irc_password
nomad/jobs/buildbot-worker
    .worker_password
```

