### PR TITLE
services/nomad/build/buildbot: use local repos

### DIFF
--- a/services/nomad/build/buildbot-worker.nomad
+++ b/services/nomad/build/buildbot-worker.nomad
@@ -72,6 +72,7 @@ job "buildbot-worker" {
 
         config {
           image = "ghcr.io/void-linux/infra-buildbot-builder:20240928R1"
+          volumes = [ "local/xbps-repos.conf:/usr/share/xbps.d/00-repository-main.conf" ]
           cap_add = ["sys_admin"]
         }
 
@@ -128,6 +129,20 @@ EOF
 Void Linux Buildbot builder for ${group.value.name} running on {{ env "attr.unique.hostname" -}}
 EOF
           destination = "local/info/host"
+        }
+
+        template {
+          data = <<EOF
+repository=/hostdir/binpkgs/bootstrap
+repository=/hostdir/binpkgs
+repository=/hostdir/binpkgs/nonfree
+{{ if eq "${group.value.name}" "glibc" }}
+repository=/hostdir/binpkgs/multilib/bootstrap
+repository=/hostdir/binpkgs/multilib
+repository=/hostdir/binpkgs/multilib/nonfree
+{{ end }}
+EOF
+          destination = "local/xbps-repos.conf"
         }
 
         template {

--- a/services/nomad/build/buildbot.cfg
+++ b/services/nomad/build/buildbot.cfg
@@ -164,7 +164,8 @@ def make_xbps_bulk_cmd(props):
     if props.getProperty('cross') == 'True':
         command += ['-a', props.getProperty('target')]
     else:
-        command += ['-a', 'native-', props.getProperty('host')]
+        command += ['-a', 'native-' + props.getProperty('host')]
+    command += ['--']
 
     return command
 


### PR DESCRIPTION
xbps-checkvers doesn't work with remote repos (as are in the default conf) and we should be using local repos anyways.

**THIS HAS BEEN DEPLOYED**
