### PR TITLE
services/nomad/apps/ircbot: serve on ircbot.voidlinux.org

### DIFF
--- a/services/nomad/apps/ircbot.nomad
+++ b/services/nomad/apps/ircbot.nomad
@@ -18,7 +18,7 @@ job "ircbot" {
       port = "http"
       meta {
         nginx_enable = "true"
-        nginx_names = "ircbot.s.voidlinux.org"
+        nginx_names = "ircbot.voidlinux.org"
       }
     }
 


### PR DESCRIPTION
the github wehbook was being sent to ircbot.voidlinux.org while the
webhook handler was listening on ircbot.s.voidlinux.org, so the two were
never connecting.
