### PR TITLE
services/nomad/build/buildbot: increase memory limit to work around upstream bug

### DIFF
--- a/services/nomad/build/buildbot.nomad
+++ b/services/nomad/build/buildbot.nomad
@@ -64,6 +64,12 @@ job "buildbot" {
         ports = ["http", "worker"]
       }
 
+      resources {
+        // see https://github.com/buildbot/buildbot/issues/3011
+        // (fixed in buildbot 4.1.0)
+        memory = 2048
+      }
+
       meta {
         // set to "true" to create or upgrade the database when starting
         db-upgrade = "false"


### PR DESCRIPTION
see https://github.com/buildbot/buildbot/issues/3011. this should be fixed when upgrading to 4.1.0

**this change has been applied**
