### PR TITLE
disable sync to b-hel-fi, add filters to buildsync

### DIFF
--- a/services/nomad/build/buildsync.nomad
+++ b/services/nomad/build/buildsync.nomad
@@ -59,6 +59,11 @@ sync {
     target = "rsync://buildsync-${group.value}@{{ .Address }}:{{ .Port }}/sources",
     {{- end -}}
     delay = 15,
+    filter = {
+      "- by_sha256/",
+      "- .*",
+      "- *.part",
+    },
     rsync = {
         verbose = true,
         update = true,

--- a/services/nomad/mirror/sync.nomad
+++ b/services/nomad/mirror/sync.nomad
@@ -3,6 +3,13 @@ job "sync" {
   datacenters = ["VOID-MIRROR"]
   namespace = "mirror"
 
+  # FIXME: b-hel-fi is consistently filling up when syncing chromium/electron tarballs
+  constraint {
+    attribute = "${node.unique.name}"
+    operator = "set_contains_any"
+    value = "d-hel-fi,a-fra-de"
+  }
+
   periodic {
     crons = ["* * * * *"]
     prohibit_overlap = true


### PR DESCRIPTION
### services/nomad/mirror/sync: disable syncing to b-hel-fi

b-hel-fi is already out of the DNS rotation for other reasons.

There has been a persistent issue where b-hel-fi has been filling up with files like:

```
/data/dist_sources/chromium-131.0.6778.69/.chromium-131.0.6778.69.tar.xz.c1MIVQ
/data/dist_sources/chromium-131.0.6778.69/.chromium-131.0.6778.69.tar.xz.OMWNDr
/data/dist_sources/chromium-131.0.6778.69/.chromium-131.0.6778.69.tar.xz.DE9ngv
/data/dist_sources/chromium-131.0.6778.69/.chromium-131.0.6778.69.tar.xz.T2lCDe
/data/dist_sources/chromium-131.0.6778.69/.chromium-131.0.6778.69.tar.xz.HJvalz
/data/dist_sources/chromium-131.0.6778.69/.chromium-131.0.6778.69.tar.xz.gWuXSr
/data/dist_sources/chromium-131.0.6778.69/.chromium-131.0.6778.69.tar.xz.a55q6u
/data/dist_sources/chromium-131.0.6778.69/.chromium-131.0.6778.69.tar.xz.9W7FHE
/data/dist_sources/chromium-131.0.6778.69/.chromium-131.0.6778.69.tar.xz.kgotgE
/data/dist_sources/chromium-131.0.6778.69/.chromium-131.0.6778.69.tar.xz.NEtuu3
/data/dist_sources/chromium-131.0.6778.69/.chromium-131.0.6778.69.tar.xz.zUFMZU
/data/dist_sources/chromium-131.0.6778.69/.chromium-131.0.6778.69.tar.xz.Gf3xEs
/data/dist_sources/chromium-131.0.6778.69/.chromium-131.0.6778.69.tar.xz.sKxTPI
```

when syncing chromium (and electron) distfiles. There do not seem to be any errors logged by rsync on either end, and this does not happen on d-hel-fi or a-fra-de, so I'm at a loss as to why this happens.

### services/nomad/build/buildsync: filter on sender

just removes a few bogus errors from popping up in the logs all the time

---

**THESE CHANGES HAVE BEEN APPLIED**
