### PR TITLE
services/pkg/sftpgo: update, add rsync, move env to nomad

### DIFF
--- a/services/pkg/sftpgo/Dockerfile
+++ b/services/pkg/sftpgo/Dockerfile
@@ -1,14 +1,6 @@
 FROM  ghcr.io/void-linux/void-glibc:latest
 
-RUN xbps-install -Syu xbps && xbps-install -Sy tini sftpgo NetAuth-sftpgo-hook
-
-ENV SFTPGO_HTTPD__TEMPLATES_PATH=/usr/share/sftpgo/templates \
-        SFTPGO_HTTPD__STATIC_FILES_PATH=/usr/share/sftpgo/static \
-        SFTPGO_DATA_PROVIDER__DRIVER=sqlite \
-        SFTPGO_DATA_PROVIDER__NAME=/data/sftpgo.db \
-        SFTPGO_SFTPD__HOST_KEYS=/secrets/id_rsa,/secrets/id_ecdsa,/secrets/id_ed25519 \
-        SFTPGO_DATA_PROVIDER__EXTERNAL_AUTH_HOOK=/usr/libexec/sftpgo/netauth-hook \
-        SFTPGO_NETAUTH_HOMEDIR=/data/home \
-        SFTPGO_NETAUTH_REQUIREGROUP=sftpgo
+RUN xbps-install -Syu xbps && xbps-install -yu && \
+    xbps-install -Sy tini sftpgo NetAuth-sftpgo-hook rsync
 
 ENTRYPOINT ["/usr/bin/tini", "/usr/bin/sftpgo", "serve"]


### PR DESCRIPTION
will require migration as discussed before full deployment, but the container can be updated

adding rsync will allow sftpgo to "talk" rsync: https://docs.sftpgo.com/latest/ssh/#ssh-commands