### PR TITLE
.github/workflows/build-pkg: update docker/bake-action

### DIFF
--- a/.github/workflows/build-pkg.yml
+++ b/.github/workflows/build-pkg.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Build and push images
         id: build_and_push
-        uses: docker/bake-action@v3
+        uses: docker/bake-action@v5
         with:
           push: ${{ github.event_name != 'pull_request' }}
           targets: infra-${{ inputs.service_name }}


### PR DESCRIPTION
v3 doesn't work with our version of buildx
