### PR TITLE
ansible/host_vars/b-lej-de: Set IPv6 default route.

### DIFF
--- a/ansible/host_vars/b-lej-de.m.voidlinux.org.yml
+++ b/ansible/host_vars/b-lej-de.m.voidlinux.org.yml
@@ -2,6 +2,8 @@
 network_static_routes:
   - to: default
     via: 172.31.1.1
+  - to: default
+    via: fe80::1
 
 network_static_interfaces:
   - name: eth0


### PR DESCRIPTION
Adjust the default IPv6 route based on changes at Hetzner.