### PR TITLE
ansible: Disable legacy nomad vault integration

### DIFF
--- a/ansible/roles/nomad-client/tasks/main.yml
+++ b/ansible/roles/nomad-client/tasks/main.yml
@@ -6,6 +6,8 @@
     owner: root
     group: root
     mode: 0644
+  vars:
+    nomad_retry_join_servers: "{{ groups['hashimaster'] | map('extract', void_mesh) | list | sort }}"
   notify:
     - nomad
 

--- a/ansible/roles/nomad-client/templates/40-client.hcl
+++ b/ansible/roles/nomad-client/templates/40-client.hcl
@@ -13,6 +13,10 @@ client {
     reserved_ports = "{{nomad_reserved_ports|default([])|join(",")}}"
   }
 
+  server_join {
+    retry_join = {{ nomad_retry_join_servers | to_json }}
+  }
+
   host_network "internal" {
     cidr = "192.168.99.0/24"
     interface = "void0"

--- a/ansible/roles/nomad-client/templates/40-client.hcl
+++ b/ansible/roles/nomad-client/templates/40-client.hcl
@@ -49,11 +49,6 @@ client {
 {% endif %}
 }
 
-vault {
-  enabled = true
-  address = "http://active.vault.service.consul:8200"
-}
-
 plugin "docker" {
   config {
     extra_labels = ["*"]

--- a/ansible/roles/nomad-server/files/40-server.hcl
+++ b/ansible/roles/nomad-server/files/40-server.hcl
@@ -1,4 +1,0 @@
-server {
-  enabled = true
-  heartbeat_grace = "2m"
-}

--- a/ansible/roles/nomad-server/tasks/main.yml
+++ b/ansible/roles/nomad-server/tasks/main.yml
@@ -1,11 +1,15 @@
 ---
 - name: Install configuration
-  copy:
+  template:
     src: 40-server.hcl
     dest: /etc/nomad.d/40-server.hcl
     owner: root
     group: root
     mode: 0755
+  vars:
+    nomad_other_servers: "{{ groups['hashimaster'] | difference([inventory_hostname]) }}"
+    nomad_retry_join_servers: "{{ nomad_other_servers | map('extract', void_mesh) | list | sort }}"
+  tags: [configure_nomad]
   notify:
     - nomad
 

--- a/ansible/roles/nomad-server/templates/30-secrets.hcl
+++ b/ansible/roles/nomad-server/templates/30-secrets.hcl
@@ -1,10 +1,3 @@
 server {
   encrypt = "{{lookup('file', 'secret/nomad_gossip_key')}}"
 }
-
-vault {
-  enabled = true
-  create_from_role = "nomad-cluster"
-  address = "http://active.vault.service.consul:8200"
-  token = "{{lookup('file', 'secret/nomad_vault_token')}}"
-}

--- a/ansible/roles/nomad-server/templates/40-server.hcl
+++ b/ansible/roles/nomad-server/templates/40-server.hcl
@@ -1,0 +1,8 @@
+server {
+  enabled = true
+  heartbeat_grace = "2m"
+
+  server_join {
+    retry_join = {{ nomad_retry_join_servers | to_json }}
+  }
+}

--- a/ansible/roles/nomad/files/conf
+++ b/ansible/roles/nomad/files/conf
@@ -3,10 +3,3 @@
 # We need consul and unbound first
 sv check consul >/dev/null || exit 1
 sv check unbound >/dev/null || exit 1
-
-# We're racing DNS setup here because this *has* to be up before Nomad
-# starts in order for it to get fingerprinted.
-while ! getent hosts active.vault.service.consul ; do
-    sleep 5
-    unbound-control flush_negative
-done

--- a/ansible/roles/vault/tasks/main.yml
+++ b/ansible/roles/vault/tasks/main.yml
@@ -24,7 +24,7 @@
     group: _vault
     mode: 0640
   vars:
-    vault_retry_join_servers: "{{ groups['hashimaster'] | difference(inventory_hostname) }}"
+    vault_retry_join_servers: "{{ groups['hashimaster'] | difference([inventory_hostname]) | sort }}"
   notify:
     - vault
 


### PR DESCRIPTION
Contributes to #228 .

This PR removes and disables the legacy vault integration.  We may decide to enable the new vault integration after upgrading, but for now we're content with nomad variables.