### PR TITLE
services/nomad/build/buildbot: sort packages before printing

### DIFF
--- a/services/nomad/build/buildbot.cfg
+++ b/services/nomad/build/buildbot.cfg
@@ -285,6 +285,17 @@ factory.addStep(ShellCommandWithChanges(
     workdir=builddir(),
 ))
 
+factory.addStep(steps.ShellCommand(
+    command=['make', 'sort'],
+    name='sort_packages',
+    description='sorting packages to build',
+    descriptionDone='sorted packages',
+    haltOnFailure=True,
+    logEnviron=False,
+    usePTY=True,
+    workdir=builddir(),
+))
+
 factory.addStep(steps.SetPropertyFromCommand(
     command=['make', 'print_pkgs'],
     property='packages',

--- a/services/nomad/build/buildbot.nomad
+++ b/services/nomad/build/buildbot.nomad
@@ -65,7 +65,7 @@ job "buildbot" {
       }
 
       resources {
-        memory = 1024
+        memory = 2048
       }
 
       meta {

--- a/services/pkg/buildbot-builder/Dockerfile
+++ b/services/pkg/buildbot-builder/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/void-linux/void-glibc-full:latest AS build
 
 RUN xbps-install -Suy xbps && xbps-install -uy git go
 
-ARG GO_XBPS_SRC_VERSION=0411f1b69a21103ec39ae6b0160b47cfc2c3e880
+ARG GO_XBPS_SRC_VERSION=aed3b4682c7b2d1e31447cdb1de60e817e4dada1
 
 RUN env GOBIN=/usr/local/bin GOMODCACHE=/tmp/go \
     go install -v github.com/Duncaen/go-xbps-src/cmd/xbps-src-make@$GO_XBPS_SRC_VERSION


### PR DESCRIPTION
this should fix ordering issues with split logs

not yet applied, waiting for builds to finish
