### PR TITLE
services/nomad/apps/{man-cgi,xq-api}: don't run on b-hel-fi

### DIFF
--- a/services/nomad/apps/man-cgi.nomad
+++ b/services/nomad/apps/man-cgi.nomad
@@ -3,6 +3,13 @@ job "man-cgi" {
   namespace = "apps"
   type = "system"
 
+  # FIXME: b-hel-fi is not currently syncing
+  constraint {
+    attribute = "${node.unique.name}"
+    operator = "set_contains_any"
+    value = "d-hel-fi,a-fra-de"
+  }
+
   group "man-cgi" {
     count = 1
 

--- a/services/nomad/apps/xq-api.nomad
+++ b/services/nomad/apps/xq-api.nomad
@@ -3,6 +3,13 @@ job "xq-api" {
   namespace = "apps"
   type = "system"
 
+  # FIXME: b-hel-fi is not currently syncing
+  constraint {
+    attribute = "${node.unique.name}"
+    operator = "set_contains_any"
+    value = "d-hel-fi,a-fra-de"
+  }
+
   group "xq-api" {
     count = 1
 


### PR DESCRIPTION
it's no longer syncing as of #221, so there's no reason to run these
apps on them
