### PR TITLE
Migrate to VictoriaLogs

### DIFF
--- a/ansible/host_vars/j-hel-fi.m.voidlinux.org.yml
+++ b/ansible/host_vars/j-hel-fi.m.voidlinux.org.yml
@@ -25,3 +25,6 @@ nomad_host_volumes:
   - name: etherpad-data
     path: /data/etherpad
     read_only: false
+  - name: vmlogs_data
+    path: /data/vmlogs
+    read_only: false

--- a/services/nomad/monitoring/vmlogs.nomad
+++ b/services/nomad/monitoring/vmlogs.nomad
@@ -1,0 +1,49 @@
+job "vmlogs" {
+  name        = "vmlogs"
+  type        = "service"
+  namespace   = "monitoring"
+  datacenters = ["VOID"]
+
+  group "vmlogs" {
+    count = 1
+
+    network {
+      mode = "bridge"
+      port "http" { static = 9428 }
+      port "syslog" { static = 514 }
+    }
+
+    service {
+      name     = "vmlogs"
+      port     = "http"
+      meta {
+        nginx_enable = "true"
+        nginx_names = "vmlogs.voidlinux.org"
+      }
+    }
+
+    volume "vmlogs_data" {
+      type      = "host"
+      source    = "vmlogs_data"
+      read_only = "false"
+    }
+
+    task "vmlogs" {
+      driver = "docker"
+
+      config {
+        image = "docker.io/victoriametrics/victoria-logs:v1.15.0-victorialogs"
+        args = [
+          "-storageDataPath=/data",
+          "-syslog.listenAddr.tcp=:514",
+          "-syslog.listenAddr.udp=:514",
+        ]
+      }
+
+      volume_mount {
+        volume      = "vmlogs_data"
+        destination = "/data"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Loki is a royal pain to run and breaks in weird ways when we have to restart it.  I've been running victoria logs in some other networks now and quite like it.  This is running in dual-write mode so both loki and vmlogs are receiving data concurrently.