### PR TITLE
services/nomad/build/buildbot-worker: use cpu instead of cores for scheduling

### DIFF
--- a/services/nomad/build/buildbot-worker.nomad
+++ b/services/nomad/build/buildbot-worker.nomad
@@ -5,11 +5,12 @@ job "buildbot-worker" {
 
   dynamic "group" {
     for_each = [
+      // cpu is ~equivalent to a number of cores
       // memory is ~90% of capacity
       // memory_max is ~95% of capacity
-      { name = "glibc",   jobs = 10, mem = 115840, mem_max = 122270 },
-      { name = "musl",    jobs = 6,  mem = 57690,  mem_max = 60890  },
-      { name = "aarch64", jobs = 3,  mem = 28500,  mem_max = 30500  },
+      { name = "glibc",   jobs = 10, cpu = 38100, mem = 115840, mem_max = 122270 },
+      { name = "musl",    jobs = 6,  cpu = 21700, mem = 57690,  mem_max = 60890  },
+      { name = "aarch64", jobs = 6,  cpu = 12000, mem = 28500,  mem_max = 30500  },
     ]
     labels = [ "buildbot-worker-${group.value.name}" ]
 
@@ -97,7 +98,7 @@ job "buildbot-worker" {
         }
 
         resources {
-          cores = "${group.value.jobs}"
+          cpu = "${group.value.cpu}"
           memory = "${group.value.mem}"
           memory_max = "${group.value.mem_max}"
         }


### PR DESCRIPTION
this also decouples the makejobs from the amount of cpu used to schedule with nomad

alternatively, we could keep using the `cores` reservation, but make it separate from makejobs


**APPLIED**
