### PR TITLE
builder affinity/metadata

### DIFF
--- a/ansible/host_vars/a-fsn-de.m.voidlinux.org.yml
+++ b/ansible/host_vars/a-fsn-de.m.voidlinux.org.yml
@@ -26,6 +26,9 @@ buildworker_archs:
   - armv7l
   - armv6l
 
+nomad_meta:
+  builder: "true"
+
 nomad_host_volumes:
   - name: void-packages
     path: /data/void-packages

--- a/ansible/host_vars/a-hel-fi.m.voidlinux.org.yml
+++ b/ansible/host_vars/a-hel-fi.m.voidlinux.org.yml
@@ -15,6 +15,14 @@ network_static_interfaces:
 sshd_AllowGroups:
   - build-ops
 
+buildworker_archs:
+  - x86_64-musl
+  - armv7l-musl
+  - armv6l-musl
+
+nomad_meta:
+  builder: "true"
+
 nomad_host_volumes:
   - name: terrastate
     path: /nomad/terrastate

--- a/ansible/host_vars/b-fsn-de.m.voidlinux.org.yml
+++ b/ansible/host_vars/b-fsn-de.m.voidlinux.org.yml
@@ -6,6 +6,9 @@ buildworker_archs:
   - aarch64
   - aarch64-musl
 
+nomad_meta:
+  builder: "true"
+
 nomad_host_volumes:
   - name: ccache
     path: /hostdir/ccache

--- a/services/nomad/monitoring/repo_exporter.nomad
+++ b/services/nomad/monitoring/repo_exporter.nomad
@@ -3,6 +3,12 @@ job "repo-exporter" {
   namespace   = "monitoring"
   datacenters = ["VOID"]
 
+  affinity {
+    attribute = "${meta.builder}"
+    value     = "true"
+    weight    = -100
+  }
+
   group "exporter" {
     network {
       mode = "bridge"
@@ -28,7 +34,7 @@ job "repo-exporter" {
       driver = "docker"
 
       config {
-        image = "ghcr.io/void-linux/repo-exporter:v0.1.1"
+        image = "ghcr.io/void-linux/repo-exporter:v0.1.2"
       }
 
       resources {


### PR DESCRIPTION
- ansible/host_vars: add nomad metadata for builders
- services/nomad/monitoring/repo_exporter: update to 0.1.2, keep off of builders

### NOT deployed