### PR TITLE
services/nomad/monitoring/repo_exporter: update, increase memory limit

### DIFF
--- a/services/nomad/monitoring/repo_exporter.nomad
+++ b/services/nomad/monitoring/repo_exporter.nomad
@@ -28,11 +28,11 @@ job "repo-exporter" {
       driver = "docker"
 
       config {
-        image = "ghcr.io/void-linux/repo-exporter:v0.1.1"
+        image = "ghcr.io/void-linux/repo-exporter:v0.1.2"
       }
 
       resources {
-        memory = 1000
+        memory = 1500
       }
     }
   }


### PR DESCRIPTION
seems to be OOMing a lot, give it an extra bit (or 4000)

*deployed*
