### PR TITLE
services/nomad/build/rsync-update-repo: process multilib on x86_64 too

### DIFF
--- a/services/nomad/build/rsync-update-repo
+++ b/services/nomad/build/rsync-update-repo
@@ -40,7 +40,7 @@ run() {
     done
 
     case "$ARCH" in
-        i686)
+        x86_64|i686)
             ARCH=x86_64
             for repo in /multilib /multilib/bootstrap /multilib/nonfree; do
                 process_repo "$repo"


### PR DESCRIPTION
nvidia builds the -32bit package natively in the x86_64 build, so this needs to run for x86_64 builds too.

closes: #262
